### PR TITLE
chore: update GitHub Actions test workflow 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,17 +5,17 @@ on:
   workflow_dispatch:
   pull_request:
     branches:
-      - master
+      - main
   push:
     branches:
-      - master
+      - main
 
 permissions:
   contents: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   build:


### PR DESCRIPTION

### Changes
- The default branch name has been changed from `master` to `main` in the GitHub Actions workflow file (`.github/workflows/test.yml`).  This affects the branches that trigger the workflow on pull requests and pushes.  The `cancel-in-progress` concurrency group condition was also updated to reflect this change.



### Impact
This change aligns the project with the modern best practice of using `main` as the default branch name.  It improves consistency and reduces confusion for developers. There is no direct impact on end-users or customers.
