### PR TITLE
chore: remove postbump script from .shiprc configuration

### DIFF
--- a/.shiprc
+++ b/.shiprc
@@ -1,6 +1,5 @@
 {
   "files": {
     ".version": []
-  },
-  "postbump": "npm run docs"
+  }
 }


### PR DESCRIPTION
### Changes
- Removed the `postbump` script from the `.shiprc` file.  This script previously ran `npm run docs` after bumping the version.


### Impact
This change will prevent the automatic generation of documentation after a version bump.  If documentation updates are still required after version changes, they will need to be triggered manually.