### PR TITLE
feat: implement tool filtering with required --tools parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,6 @@
 📚 [Documentation](https://auth0.com/docs/get-started/mcp) • 🚀 [Getting Started](#-getting-started) • 💻 [Supported Tools](#%EF%B8%8F-supported-tools) • 💬 [Feedback](#-feedback-and-contributing)
 </div>
 
-</br>
-
 [MCP (Model Context Protocol)](https://modelcontextprotocol.io/introduction) is an open protocol introduced by Anthropic that standardizes how large language models communicate with external tools, resources or remote services.
 
 **⚠ Beta Feature Notice:**
@@ -43,12 +41,18 @@ The Auth0 MCP Server integrates with LLMs and AI agents, allowing you to perform
 
 ### Install the Auth0 MCP Server
 
-Install Auth0 MCP Server and configure it to work with your preferred MCP client. 
+Install Auth0 MCP Server and configure it to work with your preferred MCP client. The `--tools` parameter specifies which tools should be available (defaults to `*` if not provided).
 
-**Claude Desktop**
+**Claude Desktop with all tools**
 ```bash
 npx @auth0/auth0-mcp-server init
 ```
+
+**Claude Desktop with read-only tools**
+```bash
+npx @auth0/auth0-mcp-server init --tools='auth0_list_*,auth0_get_*'
+```
+
 **Windsurf**
 
 ```bash
@@ -59,6 +63,12 @@ npx @auth0/auth0-mcp-server init --client windsurf
 
 ```bash
 npx @auth0/auth0-mcp-server init --client cursor
+```
+
+**With limited tools access**
+
+```bash
+npx @auth0/auth0-mcp-server init --client cursor --tools='auth0_list_applications,auth0_get_application'
 ```
 
 **Other MCP Clients**
@@ -77,16 +87,16 @@ To use Auth0 MCP Server with any other MCP Client, you can manually add this con
       }
     }
   }
+}
 ```
-</br>
+
+You can add `--tools='<pattern>'` to the args array to control which tools are available. See [Security Best Practices](#-security-best-practices-for-tool-access) for recommended patterns.
 
 ### Authenticate with Auth0
 Your browser will automatically open to initiate the OAuth 2.0 device authorization flow. Log into your Auth0 account and grant the requested permissions. 
 
 > [!NOTE]
 > Credentials are securely stored in your system's keychain. You can optionally verify storage through your keychain management tool. Checkout [Authentication](#-authentication) for more info. 
-
-</br>
 
 ### Verify your integration
 
@@ -95,8 +105,6 @@ Restart your MCP Client(Claude, Windsurf, Cursor, etc...) and ask it to help you
 <div align="left">
   <img src="https://cdn.auth0.com/website/mcp/assets/help-image-01.png" alt="Claude installed Help Image" width="300">
 </div>
-
-</br>
 
 ## 🛠️ Supported Tools
 
@@ -152,6 +160,38 @@ The Auth0 MCP Server provides the following tools for Claude to interact with yo
 | `auth0_update_form`    | Update an existing Auth0 form     | - `Update the colors on our login form to match our new brand guidelines` <br> - `Add a privacy policy link to our signup form` <br> - `Change the logo on our password reset form` |
 | `auth0_publish_form`   | Publish an Auth0 form             | - `Publish my updated login form` <br> - `Make the new signup form live` <br> - `Deploy the password reset form to production`                |
 
+### 🔒 Security Best Practices for Tool Access
+
+When configuring the Auth0 MCP Server, it's important to follow security best practices by limiting tool access based on your specific needs. The server provides flexible configuration options that let you control which tools AI assistants can access.
+
+You can easily restrict tool access using the `--tools` flag when starting the server:
+
+```bash
+# Enable only read-only operations
+npx @auth0/auth0-mcp-server run --tools='auth0_list_*,auth0_get_*'
+
+# Limit to just application-related tools
+npx @auth0/auth0-mcp-server run --tools='auth0_*_application*'
+
+# Restrict to only log viewing capabilities
+npx @auth0/auth0-mcp-server run --tools='auth0_list_logs,auth0_get_log'
+
+# Run the server with all tools enabled
+npx @auth0/auth0-mcp-server run --tools='*'
+```
+
+This approach offers several important benefits:
+
+1. **Enhanced Security**: By limiting available tools to only what's needed, you reduce the potential attack surface and prevent unintended modifications to your Auth0 tenant.
+
+2. **Better Performance**: Providing fewer tools to AI assistants actually improves performance. When models have access to many tools, they use more of their context window to reason about which tools to use. With a focused set of tools, you'll get faster and more relevant responses.
+
+3. **Resource-Based Access Control**: You can configure different instances of the MCP server with different tool sets based on specific needs - development environments might need full access, while production environments could be limited to read operations only.
+
+4. **Simplified Auditing**: With limited tools, it's easier to track which operations were performed through the AI assistant.
+
+For most use cases, start with the minimum set of tools needed and add more only when required. This follows the principle of least privilege - a fundamental security best practice.
+
 
 ## 🕸️ Architecture
 
@@ -169,8 +209,6 @@ The server handles authentication, request validation, and secure communication 
 
 > [!NOTE]
 > The server operates as a local process that connects to Claude Desktop, enabling secure communication without exposing your Auth0 credentials.
-
-</br>
 
 ## 🔐 Authentication
 
@@ -219,30 +257,13 @@ The server uses OAuth 2.0 device authorization flow for secure authentication wi
   <img src="https://cdn.auth0.com/website/mcp/assets/mcp-server-auth.png" alt="Authentication Sequence Diagram" width="800">
 </div>
 
-</br>
-
 ## 🩺 Troubleshooting
 
-Get command line help: View a list of supported commands and usage examples
+When encountering issues with the Auth0 MCP Server, several troubleshooting options are available to help diagnose and resolve problems.
 
+Start troubleshooting by exploring all available commands and options:
 ```bash
-# Command help
 npx @auth0/auth0-mcp-server help
-
-# Initialize the server (authenticate and configure)
-npx @auth0/auth0-mcp-server init
-
-# Initialize with specific scopes (supports glob patterns)
-npx @auth0/auth0-mcp-server init --scopes 'read:*,create:clients'
-
-# Run the server
-npx @auth0/auth0-mcp-server run
-
-# Display current session information
-npx @auth0/auth0-mcp-server session
-
-# Remove Auth0 tokens from keychain
-npx @auth0/auth0-mcp-server logout
 ```
 
 ### 🚥 Operation Modes
@@ -295,9 +316,10 @@ To use Auth0 MCP Server with any other MCP Client, you can add this configuratio
 ```
 
 > [!NOTE]  
-> you can manually update if needed or if any unexpected errors occur during the npx init command.
+> You can manually update if needed or if any unexpected errors occur during the npx init command.
 
 ### 🚨 Common Issues
+
 1. **Authentication Failures**
 
    - Ensure you have the correct permissions in your Auth0 tenant
@@ -317,8 +339,6 @@ To use Auth0 MCP Server with any other MCP Client, you can add this configuratio
 
 > [!TIP]
 > Most connection issues can be resolved by restarting both the server and Claude Desktop.
-
-</br>
 
 ## 📋 Debug logs
 
@@ -344,7 +364,6 @@ For detailed MCP Server logs, run the server in debug mode:
 ```bash
 DEBUG=auth0-mcp npx @auth0/auth0-mcp-server run
 ```
-</br>
 
 ## 👨‍💻 Development
 
@@ -373,8 +392,6 @@ npm run local-setup
 > [!NOTE]
 > This server requires [Node.js v18 or higher](https://nodejs.org/en/download).
 
-</br>
-
 ## 🔒 Security
 
 The Auth0 MCP Server prioritizes security:
@@ -393,8 +410,6 @@ The Auth0 MCP Server prioritizes security:
 > [!CAUTION]
 > Always review the permissions requested during the authentication process to ensure they align with your security requirements.
 
-</br>
-
 ## 💬 Feedback and Contributing
 
 We appreciate feedback and contributions to this project! Before you get started, please see:
@@ -409,8 +424,6 @@ To provide feedback or report a bug, please [raise an issue on our issue tracker
 ### Vulnerability Reporting
 
 Please do not report security vulnerabilities on the public GitHub issue tracker. The [Responsible Disclosure Program](https://auth0.com/whitehat) details the procedure for disclosing security issues.
-
-</br>
 
 ## 📄 License
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ npx @auth0/auth0-mcp-server init
 
 **Claude Desktop with read-only tools**
 ```bash
-npx @auth0/auth0-mcp-server init --tools='auth0_list_*,auth0_get_*'
+npx @auth0/auth0-mcp-server init --tools 'auth0_list_*,auth0_get_*'
 ```
 
 **Windsurf**
@@ -68,7 +68,7 @@ npx @auth0/auth0-mcp-server init --client cursor
 **With limited tools access**
 
 ```bash
-npx @auth0/auth0-mcp-server init --client cursor --tools='auth0_list_applications,auth0_get_application'
+npx @auth0/auth0-mcp-server init --client cursor --tools 'auth0_list_applications,auth0_get_application'
 ```
 
 **Other MCP Clients**
@@ -90,7 +90,7 @@ To use Auth0 MCP Server with any other MCP Client, you can manually add this con
 }
 ```
 
-You can add `--tools='<pattern>'` to the args array to control which tools are available. See [Security Best Practices](#-security-best-practices-for-tool-access) for recommended patterns.
+You can add `--tools '<pattern>'` to the args array to control which tools are available. See [Security Best Practices](#-security-best-practices-for-tool-access) for recommended patterns.
 
 ### Authenticate with Auth0
 Your browser will automatically open to initiate the OAuth 2.0 device authorization flow. Log into your Auth0 account and grant the requested permissions. 
@@ -168,16 +168,16 @@ You can easily restrict tool access using the `--tools` flag when starting the s
 
 ```bash
 # Enable only read-only operations
-npx @auth0/auth0-mcp-server run --tools='auth0_list_*,auth0_get_*'
+npx @auth0/auth0-mcp-server run --tools 'auth0_list_*,auth0_get_*'
 
 # Limit to just application-related tools
-npx @auth0/auth0-mcp-server run --tools='auth0_*_application*'
+npx @auth0/auth0-mcp-server run --tools 'auth0_*_application*'
 
 # Restrict to only log viewing capabilities
-npx @auth0/auth0-mcp-server run --tools='auth0_list_logs,auth0_get_log'
+npx @auth0/auth0-mcp-server run --tools 'auth0_list_logs,auth0_get_log'
 
 # Run the server with all tools enabled
-npx @auth0/auth0-mcp-server run --tools='*'
+npx @auth0/auth0-mcp-server run --tools '*'
 ```
 
 This approach offers several important benefits:

--- a/src/clients/claude.ts
+++ b/src/clients/claude.ts
@@ -65,7 +65,7 @@ async function updateClaudeConfig(configPath: string, options: ClientOptions) {
 
   config.mcpServers['auth0'] = {
     command: 'npx',
-    args: ['-y', '@auth0/auth0-mcp-server', 'run', `--tools ${options.tools.join(',')}`],
+    args: ['-y', '@auth0/auth0-mcp-server', 'run', '--tools', `${options.tools.join(',')}`],
     capabilities: ['tools'],
     env: {
       DEBUG: 'auth0-mcp',

--- a/src/clients/claude.ts
+++ b/src/clients/claude.ts
@@ -65,7 +65,7 @@ async function updateClaudeConfig(configPath: string, options: ClientOptions) {
 
   config.mcpServers['auth0'] = {
     command: 'npx',
-    args: ['-y', '@auth0/auth0-mcp-server', 'run', `--tools=${options.tools.join(',')}`],
+    args: ['-y', '@auth0/auth0-mcp-server', 'run', `--tools ${options.tools.join(',')}`],
     capabilities: ['tools'],
     env: {
       DEBUG: 'auth0-mcp',

--- a/src/clients/cursor.ts
+++ b/src/clients/cursor.ts
@@ -64,7 +64,7 @@ async function updateCursorConfig(configPath: string, options: ClientOptions) {
 
   config.mcpServers['auth0'] = {
     command: 'npx',
-    args: ['-y', '@auth0/auth0-mcp-server', 'run', `--tools ${options.tools.join(',')}`],
+    args: ['-y', '@auth0/auth0-mcp-server', 'run', '--tools', `${options.tools.join(',')}`],
     env: {
       DEBUG: 'auth0-mcp',
     },

--- a/src/clients/cursor.ts
+++ b/src/clients/cursor.ts
@@ -64,7 +64,7 @@ async function updateCursorConfig(configPath: string, options: ClientOptions) {
 
   config.mcpServers['auth0'] = {
     command: 'npx',
-    args: ['-y', '@auth0/auth0-mcp-server', 'run', `--tools=${options.tools.join(',')}`],
+    args: ['-y', '@auth0/auth0-mcp-server', 'run', `--tools ${options.tools.join(',')}`],
     env: {
       DEBUG: 'auth0-mcp',
     },

--- a/src/clients/windsurf.ts
+++ b/src/clients/windsurf.ts
@@ -65,7 +65,7 @@ async function updateWindsurfConfig(configPath: string, options: ClientOptions) 
 
   config.mcpServers['auth0'] = {
     command: 'npx',
-    args: ['-y', '@auth0/auth0-mcp-server', 'run', `--tools=${options.tools.join(',')}`],
+    args: ['-y', '@auth0/auth0-mcp-server', 'run', `--tools ${options.tools.join(',')}`],
     env: {
       DEBUG: 'auth0-mcp',
     },

--- a/src/clients/windsurf.ts
+++ b/src/clients/windsurf.ts
@@ -65,7 +65,7 @@ async function updateWindsurfConfig(configPath: string, options: ClientOptions) 
 
   config.mcpServers['auth0'] = {
     command: 'npx',
-    args: ['-y', '@auth0/auth0-mcp-server', 'run', `--tools ${options.tools.join(',')}`],
+    args: ['-y', '@auth0/auth0-mcp-server', 'run', '--tools', `${options.tools.join(',')}`],
     env: {
       DEBUG: 'auth0-mcp',
     },

--- a/src/clients/windsurf.ts
+++ b/src/clients/windsurf.ts
@@ -2,8 +2,9 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
 import chalk from 'chalk';
-import { log, logError } from '../utils/logger.js';
+import { log } from '../utils/logger.js';
 import { cliOutput } from '../utils/cli-utility.js';
+import type { ClientOptions } from '../utils/types.js';
 
 interface WindsurfMCPServer {
   args: string[];
@@ -16,9 +17,9 @@ interface WindsurfConfig {
   mcpServers: Record<string, WindsurfMCPServer>;
 }
 
-export const findAndUpdateWindsurfConfig = async () => {
+export const findAndUpdateWindsurfConfig = async (options: ClientOptions) => {
   const resolvedConfigPath = await getWindsurfConfigPath();
-  await updateWindsurfConfig(resolvedConfigPath);
+  await updateWindsurfConfig(resolvedConfigPath, options);
   cliOutput(
     `\n${chalk.green('✓')} Auth0 MCP server configured. ${chalk.yellow('Restart Windsurf')} to apply changes.\n`
   );
@@ -55,29 +56,21 @@ export async function getWindsurfConfigPath(): Promise<string> {
   return path.join(configDir, 'mcp_config.json');
 }
 
-async function updateWindsurfConfig(configPath: string) {
+async function updateWindsurfConfig(configPath: string, options: ClientOptions) {
   let config: WindsurfConfig = { mcpServers: {} };
   if (fs.existsSync(configPath)) {
-    try {
-      const configData = fs.readFileSync(configPath, 'utf-8');
-      config = JSON.parse(configData);
-    } catch (error) {
-      logError(`Error reading config file: ${(error as Error).message}`);
-    }
+    const configData = fs.readFileSync(configPath, 'utf-8');
+    config = JSON.parse(configData);
   }
 
   config.mcpServers['auth0'] = {
     command: 'npx',
-    args: ['-y', '@auth0/auth0-mcp-server', 'run'],
+    args: ['-y', '@auth0/auth0-mcp-server', 'run', `--tools=${options.tools.join(',')}`],
     env: {
       DEBUG: 'auth0-mcp',
     },
   };
 
-  try {
-    fs.writeFileSync(configPath, JSON.stringify(config, null, 2));
-    log(`Updated Windsurf config file at: ${configPath}`);
-  } catch (error) {
-    logError(`Error writing config file: ${(error as Error).message}`);
-  }
+  fs.writeFileSync(configPath, JSON.stringify(config, null, 2));
+  log(`Updated Windsurf config file at: ${configPath}`);
 }

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -7,9 +7,10 @@ import { promptForScopeSelection } from '../utils/cli-utility.js';
 import { getAllScopes } from '../utils/scopes.js';
 import { Glob } from '../utils/glob.js';
 import chalk from 'chalk';
+import type { ClientOptions } from '../utils/types.js';
 
 /**
- * Client configuration options supported by the application
+ * Supported client types
  */
 export type ClientName = 'claude' | 'windsurf' | 'cursor';
 
@@ -19,25 +20,50 @@ export type ClientName = 'claude' | 'windsurf' | 'cursor';
 export interface InitOptions {
   client: ClientName;
   scopes?: string[];
+  tools: string[];
+}
+
+interface ClientAction {
+  message: string;
+  action: (options: ClientOptions) => Promise<void>;
 }
 
 /**
- * Resolves scopes based on command options
+ * Maps client names to their config functions and messages
+ */
+const CLIENT_CONFIGS: Record<ClientName, ClientAction> = {
+  windsurf: {
+    message: 'Configuring Windsurf as client...',
+    action: findAndUpdateWindsurfConfig,
+  },
+  cursor: {
+    message: 'Configuring Cursor as client...',
+    action: findAndUpdateCursorConfig,
+  },
+  claude: {
+    message: 'Configuring Claude as client default...',
+    action: findAndUpdateClaudeConfig,
+  },
+};
+
+/**
+ * Resolves scope patterns to actual scope values
  *
- * @param {string[] | undefined} scopesOption - Scopes option from commander
+ * @param {string[] | undefined} scopePatterns - Scope patterns from command line
  * @returns {Promise<string[]>} - The selected scopes
  */
-async function resolveScopes(scopesOption?: string[]): Promise<string[]> {
-  if (!scopesOption || scopesOption.length === 0) {
+async function resolveScopes(scopePatterns?: string[]): Promise<string[]> {
+  // If no scopes provided, prompt user for selection
+  if (!scopePatterns?.length) {
     return promptForScopeSelection();
   }
 
-  // Match patterns against available scopes
   const allAvailableScopes = getAllScopes();
   const matchedScopes = new Set<string>();
   const invalidScopes = new Set<string>();
 
-  for (const pattern of scopesOption) {
+  // Match patterns against available scopes
+  for (const pattern of scopePatterns) {
     let foundMatch = false;
     const glob = new Glob(pattern);
 
@@ -48,7 +74,7 @@ async function resolveScopes(scopesOption?: string[]): Promise<string[]> {
       }
     }
 
-    // Track invalid scopes (non-wildcard patterns with no matches)
+    // Track non-wildcard patterns that didn't match anything
     if (!glob.hasWildcards() && !foundMatch) {
       invalidScopes.add(pattern);
     }
@@ -73,56 +99,61 @@ async function resolveScopes(scopesOption?: string[]): Promise<string[]> {
 }
 
 /**
- * Client configuration mapping
- */
-interface ClientConfig {
-  message: string;
-  action: () => Promise<void>;
-}
-
-/**
- * Configures the specified client
+ * Configures the specified client with options
  *
  * @param {ClientName} clientName - Name of the client to configure
- * @returns {Promise<void>}
+ * @param {InitOptions} options - Configuration options
  */
-async function configureClient(clientName: ClientName): Promise<void> {
-  const clientConfigs: Record<ClientName, ClientConfig> = {
-    windsurf: {
-      message: 'Configuring Windsurf as client...',
-      action: findAndUpdateWindsurfConfig,
-    },
-    cursor: {
-      message: 'Configuring Cursor as client...',
-      action: findAndUpdateCursorConfig,
-    },
-    claude: {
-      message: 'Configuring Claude as client default...',
-      action: findAndUpdateClaudeConfig,
-    },
+async function configureClient(clientName: ClientName, options: InitOptions): Promise<void> {
+  const config = CLIENT_CONFIGS[clientName];
+  log(config.message);
+
+  const clientOptions: ClientOptions = {
+    tools: options.tools,
   };
 
-  const config = clientConfigs[clientName];
-  log(config.message);
-  await config.action();
+  await config.action(clientOptions);
 }
 
 /**
- * Initializes the Auth0 MCP server by handling scope selection, authorization,
- * and client configuration.
+ * Initializes the Auth0 MCP server with the specified client, tools and scopes.
  *
- * @param {InitOptions} options - Command options from commander
- * @returns {Promise<void>}
+ * This function orchestrates the complete initialization process by:
+ * 1. Resolving and validating requested scopes
+ * 2. Obtaining authorization through the device flow
+ * 3. Configuring the selected client (Claude, Windsurf, or Cursor)
+ *
+ * @param {InitOptions} options - Configuration options including:
+ *   - client: The target client to configure ('claude', 'windsurf', or 'cursor')
+ *   - scopes: Optional scope patterns for authorization (will prompt if omitted)
+ *   - tools: Tool patterns to enable (e.g., ['auth0_list_*'])
+ *
+ * @returns {Promise<void>} A promise that resolves when initialization is complete
+ *
+ * @throws {Error} If authorization fails or client configuration encounters an error
+ *
+ * @example
+ * // Initialize with Claude client and all tools
+ * await init({ client: 'claude', tools: ['*'] });
+ *
+ * @example
+ * // Initialize with Windsurf client and specific tools
+ * await init({
+ *   client: 'windsurf',
+ *   tools: ['auth0_list_*', 'auth0_get_*'],
+ *   scopes: ['read:*']
+ * });
  */
 const init = async (options: InitOptions): Promise<void> => {
   log('Initializing Auth0 MCP server...');
+  log(`Configuring server with selected tools: ${options.tools.join(', ')}`);
 
-  // Handle scope resolution
+  // Handle scope resolution and authorization
   const selectedScopes = await resolveScopes(options.scopes);
   await requestAuthorization(selectedScopes);
 
-  // Handle client configuration
-  await configureClient(options.client);
+  // Configure the requested client
+  await configureClient(options.client, options);
 };
 
 export default init;

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -1,5 +1,5 @@
 import { startServer } from '../server.js';
-import { log, logError } from '../utils/logger.js';
+import { log, logError, logInfo } from '../utils/logger.js';
 import * as os from 'os';
 
 /**
@@ -22,7 +22,7 @@ const run = async (options: RunOptions): Promise<void> => {
       log(`Set HOME environment variable to ${process.env.HOME}`);
     }
 
-    log(`Starting server with selected tools: ${options.tools.join(', ')}`);
+    logInfo(`Starting server with selected tools: ${options.tools.join(', ')}`);
     await startServer(options);
   } catch (error) {
     logError('Fatal error starting server:', error);

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -5,22 +5,25 @@ import * as os from 'os';
 /**
  * Command options for the run command
  */
-export type RunOptions = Record<string, never>;
+export interface RunOptions {
+  tools: string[];
+}
 
 /**
  * Main function to start server
  *
- * @param {RunOptions} _options - Command options from commander (unused)
+ * @param {RunOptions} options - Command options
  * @returns {Promise<void>}
  */
-const run = async (_options?: RunOptions): Promise<void> => {
+const run = async (options: RunOptions): Promise<void> => {
   try {
     if (!process.env.HOME) {
       process.env.HOME = os.homedir();
       log(`Set HOME environment variable to ${process.env.HOME}`);
     }
 
-    await startServer();
+    log(`Starting server with selected tools: ${options.tools.join(', ')}`);
+    await startServer(options);
   } catch (error) {
     logError('Fatal error starting server:', error);
     process.exit(1);

--- a/src/index.ts
+++ b/src/index.ts
@@ -72,9 +72,9 @@ with Claude Desktop, enabling AI-assisted management of your Auth0 tenant.`
     `
 Examples:
   npx ${packageName} init
-  npx ${packageName} init --tools='auth0_*' --client claude
-  npx ${packageName} init --tools='auth0_*_applications' --client windsurf
-  npx ${packageName} init --tools='auth0_list_*,auth0_get_*' --client cursor
+  npx ${packageName} init --tools 'auth0_*' --client claude
+  npx ${packageName} init --tools 'auth0_*_applications' --client windsurf
+  npx ${packageName} init --tools 'auth0_list_*,auth0_get_*' --client cursor
   npx ${packageName} run
   npx ${packageName} session
   npx ${packageName} logout

--- a/src/utils/tools.ts
+++ b/src/utils/tools.ts
@@ -1,0 +1,143 @@
+import { Tool } from './types.js';
+import { log } from './logger.js';
+import { Glob } from './glob.js';
+
+/**
+ * Filters the provided tools collection based on specified glob patterns.
+ * This function processes the input patterns against available tools to determine
+ * which tools should be returned. It handles special cases like wildcard patterns,
+ * empty pattern arrays, and pattern matching errors.
+ *
+ * @param allTools - Complete collection of available tools to be filtered
+ * @param patterns - Optional glob patterns to filter tools by (e.g., 'auth0*', 'jwt-*')
+ *                   If omitted or empty, all tools will be returned
+ *                   A single '*' pattern will return all tools
+ * @returns Array of Tool objects that match the specified patterns
+ *          Returns all tools if no patterns provided or on error
+ *
+ * @example
+ * // Return all tools that start with "auth"
+ * const authTools = getAvailableTools(tools, ['auth*']);
+ *
+ * @example
+ * // Return all tools (either approach works)
+ * const allTools1 = getAvailableTools(tools);
+ * const allTools2 = getAvailableTools(tools, ['*']);
+ *
+ * @example
+ * // Return tools matching multiple patterns
+ * const selectedTools = getAvailableTools(tools, ['auth*', 'jwt-*']);
+ *
+ * @see {@link validatePatterns} for pattern validation against available tools
+ * @see {@link Glob} for the pattern matching implementation
+ */
+export function getAvailableTools(allTools: Tool[], patterns?: string[]): Tool[] {
+  // Return all tools if no filters specified
+  if (!patterns?.length) {
+    return allTools;
+  }
+
+  try {
+    // Special case for global wildcard
+    if (patterns.length === 1 && patterns[0] === '*') {
+      return allTools;
+    }
+
+    // Compile glob patterns once for performance
+    const globs = patterns.map((pattern) => new Glob(pattern));
+
+    // Track matching tools and matches per pattern
+    const enabledToolNames = new Set<string>();
+    const matchesByPattern = new Map<string, number>();
+
+    // For each tool, check if it matches any pattern
+    for (const tool of allTools) {
+      for (const glob of globs) {
+        if (glob.matches(tool.name)) {
+          enabledToolNames.add(tool.name);
+
+          // Count matches per pattern for logging
+          const patternString = glob.toString();
+          matchesByPattern.set(patternString, (matchesByPattern.get(patternString) || 0) + 1);
+
+          // Once we find a match, no need to check other patterns
+          break;
+        }
+      }
+    }
+
+    // Log match counts for wildcard patterns for debugging
+    for (const [pattern, count] of matchesByPattern.entries()) {
+      if (pattern.includes('*')) {
+        log(`Glob pattern '${pattern}' matched ${count} tools`);
+      }
+    }
+
+    // Create the final filtered tool list
+    const availableTools = allTools.filter((tool) => enabledToolNames.has(tool.name));
+    log(`Selected ${availableTools.length} available tools based on patterns`);
+
+    return availableTools;
+  } catch (error) {
+    // Log error and return all tools as fallback
+    log(
+      `Error determining available tools: ${error instanceof Error ? error.message : String(error)}`
+    );
+    return allTools;
+  }
+}
+
+/**
+ * Validates tool patterns against available tools to ensure each pattern matches at least one tool.
+ * This function verifies that each provided pattern (including glob patterns) corresponds to
+ * at least one available tool, throwing specific errors for different validation scenarios.
+ *
+ * @param patterns - Array of tool name patterns to validate
+ *                   Can include glob patterns with wildcards (e.g., 'auth0*')
+ *                   Empty array or undefined will skip validation
+ * @param availableTools - Collection of Tool objects to validate patterns against
+ *
+ * @throws {Error} If availableTools is not a valid array or is empty
+ * @throws {Error} If any pattern doesn't match at least one tool name, with different
+ *                 error messages for exact matches vs. wildcard patterns
+ *
+ * @example
+ * // Validate specific tool names
+ * validatePatterns(['auth0-jwt', 'auth0-management'], tools);
+ *
+ * @example
+ * // Validate with glob patterns
+ * validatePatterns(['auth0*', 'jwt-*'], tools);
+ *
+ * @see {@link Glob} for the pattern matching implementation
+ * @see {@link getAvailableTools} for filtering tools using these patterns
+ */
+export function validatePatterns(patterns: string[], availableTools: Tool[]): void {
+  // Skip validation if patterns array is empty
+  if (!patterns || patterns.length === 0) {
+    return;
+  }
+
+  // Input validation
+  if (!availableTools || !Array.isArray(availableTools)) {
+    throw new Error('Invalid tools array provided for validation');
+  }
+
+  if (availableTools.length === 0) {
+    throw new Error('No tools available for pattern validation');
+  }
+
+  // Extract tool names for faster matching
+  const toolNames = availableTools.map((tool) => tool.name);
+
+  // Validate each pattern
+  for (const pattern of patterns) {
+    const glob = new Glob(pattern);
+    const matchesAnyTool = toolNames.some((name) => glob.matches(name));
+
+    if (!matchesAnyTool) {
+      const errorPrefix = pattern.includes('*') ? `No tools match the pattern` : `Invalid tool`;
+      throw new Error(`${errorPrefix}: ${pattern}. Accepted tools are: ${toolNames.join(', ')}`);
+    }
+  }
+}

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -28,6 +28,11 @@ export interface HandlerResponse {
   isError: boolean;
 }
 
+// Client Options interface
+export interface ClientOptions {
+  tools: string[];
+}
+
 // Auth0 response interfaces
 export interface Auth0Application {
   client_id: string;

--- a/test/commands/run.test.ts
+++ b/test/commands/run.test.ts
@@ -70,19 +70,6 @@ describe('Run Module', () => {
     expect(process.exit).not.toHaveBeenCalled();
   });
 
-  it('should require tools parameter', async () => {
-    // Create mock function to test the check in index.ts
-    const checkToolsArg = (args: string[]) => {
-      return args.some((arg) => arg.startsWith('--tools='));
-    };
-
-    // Test with no tools arg
-    expect(checkToolsArg([])).toBe(false);
-
-    // Test with tools arg
-    expect(checkToolsArg(['--tools=auth0_list_*'])).toBe(true);
-  });
-
   it('should set HOME environment variable if not set', async () => {
     // Remove HOME environment variable
     delete process.env.HOME;

--- a/test/commands/run.test.ts
+++ b/test/commands/run.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import run from '../../src/commands/run.js';
 import { startServer } from '../../src/server';
-import { log } from '../../src/utils/logger';
+import { log, logInfo } from '../../src/utils/logger';
 import * as os from 'os';
 
 // Mock dependencies first, before any imports
@@ -64,7 +64,7 @@ describe('Run Module', () => {
     await run(options);
 
     expect(startServer).toHaveBeenCalledWith(options);
-    expect(log).toHaveBeenCalledWith(
+    expect(logInfo).toHaveBeenCalledWith(
       'Starting server with selected tools: auth0_list_applications, auth0_get_application'
     );
     expect(process.exit).not.toHaveBeenCalled();

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -70,15 +70,15 @@ describe('Index Module', () => {
     expect(helpText).toContain('https://github.com/auth0/auth0-mcp-server');
 
     // Check for example commands
-    expect(helpText).toContain('npx @auth0/auth0-mcp-server init --tools=');
+    expect(helpText).toContain('npx @auth0/auth0-mcp-server init --tools ');
     expect(helpText).toContain(
-      "npx @auth0/auth0-mcp-server init --tools='auth0_*' --client claude"
+      "npx @auth0/auth0-mcp-server init --tools 'auth0_*' --client claude"
     );
     expect(helpText).toContain(
-      "npx @auth0/auth0-mcp-server init --tools='auth0_*_applications' --client windsurf"
+      "npx @auth0/auth0-mcp-server init --tools 'auth0_*_applications' --client windsurf"
     );
     expect(helpText).toContain(
-      "npx @auth0/auth0-mcp-server init --tools='auth0_list_*,auth0_get_*' --client cursor"
+      "npx @auth0/auth0-mcp-server init --tools 'auth0_list_*,auth0_get_*' --client cursor"
     );
     expect(helpText).toContain('npx @auth0/auth0-mcp-server run');
   });

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -38,7 +38,7 @@ vi.mock('module', () => {
   };
 });
 
-describe('Commander Help Integration', () => {
+describe('Index Module', () => {
   beforeEach(() => {
     vi.clearAllMocks();
 
@@ -48,7 +48,7 @@ describe('Commander Help Integration', () => {
 
   it('validates the integration with Commander.js help system', async () => {
     // Import the index file to initialize Commander
-    await import('../../src/index.js');
+    await import('../src/index.js');
 
     // Verify version was called with the package version
     expect(mockVersion).toHaveBeenCalled();
@@ -70,11 +70,22 @@ describe('Commander Help Integration', () => {
     expect(helpText).toContain('https://github.com/auth0/auth0-mcp-server');
 
     // Check for example commands
-    expect(helpText).toContain('npx @auth0/auth0-mcp-server init');
-    expect(helpText).toContain('npx @auth0/auth0-mcp-server init --client claude');
-    expect(helpText).toContain('npx @auth0/auth0-mcp-server init --client windsurf');
-    expect(helpText).toContain('npx @auth0/auth0-mcp-server init --client cursor');
+    expect(helpText).toContain('npx @auth0/auth0-mcp-server init --tools=');
+    expect(helpText).toContain(
+      "npx @auth0/auth0-mcp-server init --tools='auth0_*' --client claude"
+    );
+    expect(helpText).toContain(
+      "npx @auth0/auth0-mcp-server init --tools='auth0_*_applications' --client windsurf"
+    );
+    expect(helpText).toContain(
+      "npx @auth0/auth0-mcp-server init --tools='auth0_list_*,auth0_get_*' --client cursor"
+    );
     expect(helpText).toContain('npx @auth0/auth0-mcp-server run');
+  });
+
+  it('sets up all required commands', async () => {
+    // Import the index file to initialize Commander
+    await import('../src/index.js');
 
     // Verify commander command setup
     expect(mockCommand).toHaveBeenCalledWith('init');

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -74,6 +74,25 @@ describe('Server', () => {
       );
     });
 
+    it('should initialize the server with filtered tools', async () => {
+      const options = { tools: ['auth0_list_applications'] };
+      const server = await startServer(options);
+
+      expect(mockLoadConfig).toHaveBeenCalledTimes(1);
+      expect(mockValidateConfig).toHaveBeenCalledWith(mockConfig);
+      expect(server).toBeDefined();
+
+      // Get the ListToolsRequestSchema handler to check filtered tools
+      const handlerCall = mockSetRequestHandler.mock.calls.find(
+        (call) => call[0] === ListToolsRequestSchema
+      );
+      expect(handlerCall).toBeDefined();
+
+      // Since the handler returns a filtered list of tools, we can't easily test that here
+      // But we can verify it was called
+      expect(handlerCall).toBeTruthy();
+    });
+
     it('should throw an error if config validation fails', async () => {
       mockValidateConfig.mockReturnValueOnce(false);
 

--- a/test/utils/tools.test.ts
+++ b/test/utils/tools.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect, vi, assert } from 'vitest';
+import { getAvailableTools, validatePatterns } from '../../src/utils/tools.js';
+import { Tool } from '../../src/utils/types.js';
+import { log } from '../../src/utils/logger.js';
+
+// Mock external dependencies
+vi.mock('../../src/utils/logger.js', () => ({
+  log: vi.fn(),
+  logError: vi.fn(),
+}));
+
+describe('Tool Utilities', () => {
+  // Common test fixtures
+  const testTools: Tool[] = [
+    { name: 'auth0_list_applications', description: 'List all applications' },
+    { name: 'auth0_get_application', description: 'Get application details' },
+    { name: 'auth0_create_application', description: 'Create application' },
+    { name: 'auth0_update_application', description: 'Update application' },
+    { name: 'auth0_list_resource_servers', description: 'List resource servers' },
+    { name: 'auth0_get_resource_server', description: 'Get resource server details' },
+  ];
+
+  describe('validatePatterns function', () => {
+    it('should not throw for valid tool names', () => {
+      expect(() => validatePatterns(['auth0_list_applications'], testTools)).not.toThrow();
+    });
+
+    it('should not throw for valid glob patterns', () => {
+      expect(() => validatePatterns(['auth0_*'], testTools)).not.toThrow();
+    });
+
+    it('should not throw for multiple valid patterns', () => {
+      expect(() => validatePatterns(['auth0_list_*', 'auth0_get_*'], testTools)).not.toThrow();
+    });
+
+    it('should validate each pattern in the array', () => {
+      expect(() =>
+        validatePatterns(['auth0_list_applications', 'nonexistent_tool'], testTools)
+      ).toThrow(/Invalid tool: nonexistent_tool/);
+    });
+
+    it("should throw for tool names that don't exist", () => {
+      expect(() => validatePatterns(['nonexistent_tool'], testTools)).toThrow(
+        /Invalid tool: nonexistent_tool/
+      );
+    });
+
+    it("should throw for glob patterns that don't match any tools", () => {
+      expect(() => validatePatterns(['xyz_*_tool'], testTools)).toThrow(
+        /No tools match the pattern/
+      );
+    });
+
+    it('should list valid tools in the error message for invalid tool names', () => {
+      try {
+        validatePatterns(['nonexistent_tool'], testTools);
+        assert.fail('Expected an error to be thrown');
+      } catch (error: any) {
+        // Error should include available tool names for user guidance
+        expect(error.message).toContain('auth0_list_applications');
+        expect(error.message).toContain('auth0_get_application');
+      }
+    });
+
+    it('should handle empty pattern array', () => {
+      expect(() => validatePatterns([], testTools)).not.toThrow();
+    });
+
+    it('should handle patterns with special regex characters', () => {
+      expect(() => validatePatterns(['auth0_list_applications+'], testTools)).toThrow(
+        /Invalid tool/
+      );
+      expect(() => validatePatterns(['auth0_[list]_applications'], testTools)).toThrow(
+        /Invalid tool/
+      );
+    });
+
+    it('should throw appropriate error for null or undefined tools array', () => {
+      expect(() => validatePatterns(['auth0_list_applications'], null as any)).toThrow();
+      expect(() => validatePatterns(['auth0_list_applications'], undefined as any)).toThrow();
+    });
+
+    it('should throw with descriptive message when no tools are provided', () => {
+      expect(() => validatePatterns(['auth0_list_applications'], [])).toThrow(
+        /no tools available/i
+      );
+    });
+  });
+
+  describe('getAvailableTools function', () => {
+    it('should return all tools when no patterns are provided', () => {
+      const result = getAvailableTools(testTools);
+      expect(result).toEqual(testTools);
+    });
+
+    it('should return all tools when patterns is an empty array', () => {
+      const result = getAvailableTools(testTools, []);
+      expect(result).toEqual(testTools);
+    });
+
+    it('should return all tools when the special "*" selector is specified', () => {
+      const result = getAvailableTools(testTools, ['*']);
+      expect(result).toEqual(testTools);
+    });
+
+    it('should filter tools by exact name match', () => {
+      const result = getAvailableTools(testTools, ['auth0_list_applications']);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].name).toBe('auth0_list_applications');
+    });
+
+    it('should filter tools by multiple specific names', () => {
+      const result = getAvailableTools(testTools, [
+        'auth0_list_applications',
+        'auth0_get_application',
+      ]);
+
+      expect(result).toHaveLength(2);
+      expect(result.map((t) => t.name)).toContain('auth0_list_applications');
+      expect(result.map((t) => t.name)).toContain('auth0_get_application');
+    });
+
+    it('should filter tools by glob pattern', () => {
+      const result = getAvailableTools(testTools, ['auth0_*_application']);
+
+      expect(result.length).toBeGreaterThan(0);
+      expect(
+        result.every((t) => t.name.startsWith('auth0_') && t.name.endsWith('_application'))
+      ).toBe(true);
+    });
+
+    it('should handle multiple glob patterns correctly', () => {
+      const result = getAvailableTools(testTools, ['auth0_get_*', '*_resource_*']);
+
+      // Verify results contain matches for both patterns
+      const hasGetTools = result.some((t) => t.name.startsWith('auth0_get_'));
+      const hasResourceTools = result.some((t) => t.name.includes('_resource_'));
+
+      expect(hasGetTools).toBe(true);
+      expect(hasResourceTools).toBe(true);
+    });
+
+    it('should handle tools with whitespace in names', () => {
+      const toolWithSpace = {
+        name: 'tool with space',
+        description: 'Test tool',
+      };
+
+      const result = getAvailableTools([toolWithSpace], ['tool with space']);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].name).toBe('tool with space');
+    });
+
+    it('should perform case-sensitive filtering', () => {
+      const result = getAvailableTools(testTools, ['AUTH0_LIST_APPLICATIONS']);
+      expect(result).toHaveLength(0); // Should not match due to case difference
+    });
+
+    // Since we can't easily mock errors with ESM, we'll test this indirectly
+    it('catches errors during tool pattern matching', () => {
+      // We need to verify the try/catch block in the code works.
+      // Since we can't easily induce an error in a test environment with ESM modules,
+      // we'll verify that the function doesn't throw even with invalid globs.
+      const result = getAvailableTools(testTools, ['[']); // Invalid regex pattern
+      expect(result).toBeDefined();
+    });
+  });
+});


### PR DESCRIPTION
### Changes

This PR adds tool filtering functionality to the Auth0 MCP Server, allowing administrators to control which tools are available to AI assistants.

Key changes include:
- Added `--tools` parameter that accepts glob patterns to filter available tools
- Enhanced all MCP client configurations (Claude, Windsurf, Cursor) to support tool filtering
- Created utility functions in `src/utils/tools.ts` to validate and filter tools
- Updated server initialization to respect tool filtering options
- Added comprehensive test coverage for the new functionality
- Updated README.md with security best practices section for tool access
- Added usage examples for limiting tool access in different scenarios

This feature significantly enhances security by allowing administrators to follow the principle of least privilege - limiting which Auth0 management operations AI assistants can perform. An additional benefit is improved performance, as AI assistants with access to fewer tools use less context window for tool selection.

Usage examples:
```bash
# Enable only read-only operations
npx @auth0/auth0-mcp-server run --tools='auth0_list_*,auth0_get_*'

# Limit to just application-related tools
npx @auth0/auth0-mcp-server run --tools='auth0_*_application*'
```

### References

- Community requests for more granular control over tool access
- Security best practices for AI assistant integrations
- Industry standard principle of least privilege

### Testing

All tests have been updated to account for the new functionality:

- Unit tests for tool filtering functions in `test/utils/tools.test.ts`
- Integration tests for client configuration with tool filtering 
- Verification of tool filtering works with all supported MCP clients
- Tests for validation logic to properly reject invalid patterns

- [x] This change adds unit test coverage
- [x] This change adds integration test coverage

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors