### PR TITLE
feat: add read-only CLI flag to restrict tool access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,18 +1,22 @@
 # Change Log
 
 ## [v0.1.0-beta.2](https://github.com/auth0/auth0-mcp-server/tree/v0.1.0-beta.2) (2025-04-24)
+
 [Full Changelog](https://github.com/auth0/auth0-mcp-server/compare/v0.1.0-beta.1...v0.1.0-beta.2)
 
 **Added**
+
 - feat: add Anonymized analytics for mcp server [\#19](https://github.com/auth0/auth0-mcp-server/pull/19) ([kushalshit27](https://github.com/kushalshit27))
 - feat: implement tool filtering with required --tools parameter [\#15](https://github.com/auth0/auth0-mcp-server/pull/15) ([btiernay](https://github.com/btiernay))
 
 **Changed**
+
 - refactor: package info management for consistency [\#20](https://github.com/auth0/auth0-mcp-server/pull/20) ([btiernay](https://github.com/btiernay))
 - chore: update local setup details view [\#2](https://github.com/auth0/auth0-mcp-server/pull/2) ([kushalshit27](https://github.com/kushalshit27))
 - feat: integrate commander.js for command processing [\#3](https://github.com/auth0/auth0-mcp-server/pull/3) ([btiernay](https://github.com/btiernay))
 
 **Fixed**
+
 - fix: update NPM downloads badge in README [\#18](https://github.com/auth0/auth0-mcp-server/pull/18) ([kushalshit27](https://github.com/kushalshit27))
 - Fixed links in readme [\#14](https://github.com/auth0/auth0-mcp-server/pull/14) ([brth31](https://github.com/brth31))
 

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ The Auth0 MCP Server provides the following tools for Claude to interact with yo
 
 When configuring the Auth0 MCP Server, it's important to follow security best practices by limiting tool access based on your specific needs. The server provides flexible configuration options that let you control which tools AI assistants can access.
 
-You can easily restrict tool access using the `--tools` flag when starting the server:
+You can easily restrict tool access using the `--tools` and `--read-only` flags when starting the server:
 
 ```bash
 # Enable only read-only operations
@@ -187,7 +187,8 @@ npx @auth0/auth0-mcp-server run --tools 'auth0_list_*,auth0_get_*'
 # Limit to just application-related tools
 npx @auth0/auth0-mcp-server run --tools 'auth0_*_application*'
 
-# Limit to read-only application-related tools
+# Limit to read-only application-related tools 
+# Note: --read-only takes priority when used with --tools
 npx @auth0/auth0-mcp-server run --tools 'auth0_*_application*' --read-only
 
 # Restrict to only log viewing capabilities
@@ -196,6 +197,9 @@ npx @auth0/auth0-mcp-server run --tools 'auth0_list_logs,auth0_get_log'
 # Run the server with all tools enabled
 npx @auth0/auth0-mcp-server run --tools '*'
 ```
+
+> [!IMPORTANT]
+> When both `--read-only` and `--tools` flags are used together, the `--read-only` flag takes priority for security. This means even if your `--tools` pattern matches non-read-only tools, only read-only operations will be available. This ensures you can rely on the `--read-only` flag as a security guardrail.
 
 This approach offers several important benefits:
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,12 @@ npx @auth0/auth0-mcp-server init
 **Claude Desktop with read-only tools**
 
 ```bash
+npx @auth0/auth0-mcp-server init --read-only
+```
+
+You can also explicitly select read-only tools:
+
+```bash
 npx @auth0/auth0-mcp-server init --tools 'auth0_list_*,auth0_get_*'
 ```
 
@@ -173,10 +179,16 @@ You can easily restrict tool access using the `--tools` flag when starting the s
 
 ```bash
 # Enable only read-only operations
+npx @auth0/auth0-mcp-server run --read-only
+
+# Alternative way to enable only read-only operations
 npx @auth0/auth0-mcp-server run --tools 'auth0_list_*,auth0_get_*'
 
 # Limit to just application-related tools
 npx @auth0/auth0-mcp-server run --tools 'auth0_*_application*'
+
+# Limit to read-only application-related tools
+npx @auth0/auth0-mcp-server run --tools 'auth0_*_application*' --read-only
 
 # Restrict to only log viewing capabilities
 npx @auth0/auth0-mcp-server run --tools 'auth0_list_logs,auth0_get_log'

--- a/src/clients/claude.ts
+++ b/src/clients/claude.ts
@@ -63,9 +63,17 @@ async function updateClaudeConfig(configPath: string, options: ClientOptions) {
     config = JSON.parse(configData);
   }
 
+  // Build args array
+  const args = ['-y', '@auth0/auth0-mcp-server', 'run', '--tools', `${options.tools.join(',')}`];
+
+  // Add read-only flag if specified
+  if (options.readOnly) {
+    args.push('--read-only');
+  }
+
   config.mcpServers['auth0'] = {
     command: 'npx',
-    args: ['-y', '@auth0/auth0-mcp-server', 'run', '--tools', `${options.tools.join(',')}`],
+    args,
     capabilities: ['tools'],
     env: {
       DEBUG: 'auth0-mcp',

--- a/src/clients/cursor.ts
+++ b/src/clients/cursor.ts
@@ -62,9 +62,17 @@ async function updateCursorConfig(configPath: string, options: ClientOptions) {
     config = JSON.parse(configData);
   }
 
+  // Build args array
+  const args = ['-y', '@auth0/auth0-mcp-server', 'run', '--tools', `${options.tools.join(',')}`];
+
+  // Add read-only flag if specified
+  if (options.readOnly) {
+    args.push('--read-only');
+  }
+
   config.mcpServers['auth0'] = {
     command: 'npx',
-    args: ['-y', '@auth0/auth0-mcp-server', 'run', '--tools', `${options.tools.join(',')}`],
+    args,
     env: {
       DEBUG: 'auth0-mcp',
     },

--- a/src/clients/windsurf.ts
+++ b/src/clients/windsurf.ts
@@ -63,9 +63,17 @@ async function updateWindsurfConfig(configPath: string, options: ClientOptions) 
     config = JSON.parse(configData);
   }
 
+  // Build args array
+  const args = ['-y', '@auth0/auth0-mcp-server', 'run', '--tools', `${options.tools.join(',')}`];
+
+  // Add read-only flag if specified
+  if (options.readOnly) {
+    args.push('--read-only');
+  }
+
   config.mcpServers['auth0'] = {
     command: 'npx',
-    args: ['-y', '@auth0/auth0-mcp-server', 'run', '--tools', `${options.tools.join(',')}`],
+    args,
     env: {
       DEBUG: 'auth0-mcp',
     },

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -22,6 +22,7 @@ export interface InitOptions {
   client: ClientName;
   scopes?: string[];
   tools: string[];
+  readOnly?: boolean;
 }
 
 interface ClientAction {
@@ -111,6 +112,7 @@ async function configureClient(clientName: ClientName, options: InitOptions): Pr
 
   const clientOptions: ClientOptions = {
     tools: options.tools,
+    readOnly: options.readOnly,
   };
 
   await config.action(clientOptions);
@@ -148,6 +150,9 @@ async function configureClient(clientName: ClientName, options: InitOptions): Pr
 const init = async (options: InitOptions): Promise<void> => {
   log('Initializing Auth0 MCP server...');
   log(`Configuring server with selected tools: ${options.tools.join(', ')}`);
+  if (options.readOnly) {
+    log('Running in read-only mode - only read operations will be available');
+  }
 
   trackEvent.trackInit(options.client);
 

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -28,10 +28,13 @@ const run = async (options: RunOptions): Promise<void> => {
 
     if (options.readOnly && options.tools.length === 1 && options.tools[0] === '*') {
       logInfo('Starting server in read-only mode');
-    } else {
-      const readOnlyPrefix = options.readOnly ? 'read-only ' : '';
+    } else if (options.readOnly) {
       logInfo(
-        `Starting server with ${readOnlyPrefix}tools matching the following pattern(s): ${options.tools.join(', ')}`
+        `Starting server in read-only mode with tools matching the following pattern(s): ${options.tools.join(', ')} (--read-only has priority)`
+      );
+    } else {
+      logInfo(
+        `Starting server with tools matching the following pattern(s): ${options.tools.join(', ')}`
       );
     }
     await startServer(options);

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -8,6 +8,7 @@ import * as os from 'os';
  */
 export interface RunOptions {
   tools: string[];
+  readOnly?: boolean;
 }
 
 /**
@@ -25,7 +26,14 @@ const run = async (options: RunOptions): Promise<void> => {
 
     trackEvent.trackServerRun();
 
-    logInfo(`Starting server with selected tools: ${options.tools.join(', ')}`);
+    if (options.readOnly && options.tools.length === 1 && options.tools[0] === '*') {
+      logInfo('Starting server in read-only mode');
+    } else {
+      const readOnlyPrefix = options.readOnly ? 'read-only ' : '';
+      logInfo(
+        `Starting server with ${readOnlyPrefix}tools matching the following pattern(s): ${options.tools.join(', ')}`
+      );
+    }
     await startServer(options);
   } catch (error) {
     logError('Fatal error starting server:', error);

--- a/src/index.ts
+++ b/src/index.ts
@@ -65,9 +65,11 @@ with Claude Desktop, enabling AI-assisted management of your Auth0 tenant.`
 Examples:
   npx ${packageName} init
   npx ${packageName} init --tools 'auth0_*' --client claude
+  npx ${packageName} init --read-only --client claude
   npx ${packageName} init --tools 'auth0_*_applications' --client windsurf
   npx ${packageName} init --tools 'auth0_list_*,auth0_get_*' --client cursor
   npx ${packageName} run
+  npx ${packageName} run --read-only
   npx ${packageName} session
   npx ${packageName} logout
   
@@ -91,6 +93,7 @@ program
     parseToolPatterns,
     ['*']
   )
+  .option('--read-only', 'Only expose read-only tools (list and get operations)', false)
   .action(init);
 
 // Run command
@@ -103,6 +106,7 @@ program
     parseToolPatterns,
     ['*']
   )
+  .option('--read-only', 'Only expose read-only tools (list and get operations)', false)
   .action(run);
 
 // Logout command

--- a/src/server.ts
+++ b/src/server.ts
@@ -14,7 +14,7 @@ import { packageVersion } from './utils/package.js';
 type ServerOptions = RunOptions;
 
 // Server implementation
-export async function startServer(options: ServerOptions) {
+export async function startServer(options?: ServerOptions) {
   try {
     log('Initializing Auth0 MCP server...');
 
@@ -34,7 +34,7 @@ export async function startServer(options: ServerOptions) {
     log(`Successfully loaded configuration for tenant: ${maskTenantName(config.tenantName)}`);
 
     // Get available tools based on options if provided
-    const availableTools = getAvailableTools(TOOLS, options?.tools);
+    const availableTools = getAvailableTools(TOOLS, options?.tools, options?.readOnly);
 
     // Create server instance
     const server = new Server(

--- a/src/tools/actions.ts
+++ b/src/tools/actions.ts
@@ -48,6 +48,7 @@ export const ACTION_TOOLS: Tool[] = [
     },
     _meta: {
       requiredScopes: ['read:actions'],
+      readOnly: true,
     },
   },
   {
@@ -62,6 +63,7 @@ export const ACTION_TOOLS: Tool[] = [
     },
     _meta: {
       requiredScopes: ['read:actions'],
+      readOnly: true,
     },
   },
   {

--- a/src/tools/applications.ts
+++ b/src/tools/applications.ts
@@ -28,6 +28,7 @@ export const APPLICATION_TOOLS: Tool[] = [
     },
     _meta: {
       requiredScopes: ['read:clients'],
+      readOnly: true,
     },
   },
   {
@@ -42,6 +43,7 @@ export const APPLICATION_TOOLS: Tool[] = [
     },
     _meta: {
       requiredScopes: ['read:clients'],
+      readOnly: true,
     },
   },
   {

--- a/src/tools/forms.ts
+++ b/src/tools/forms.ts
@@ -20,6 +20,7 @@ export const FORM_TOOLS: Tool[] = [
     },
     _meta: {
       requiredScopes: ['read:forms'],
+      readOnly: true,
     },
   },
   {
@@ -34,6 +35,7 @@ export const FORM_TOOLS: Tool[] = [
     },
     _meta: {
       requiredScopes: ['read:forms'],
+      readOnly: true,
     },
   },
   {

--- a/src/tools/logs.ts
+++ b/src/tools/logs.ts
@@ -41,6 +41,7 @@ export const LOG_TOOLS: Tool[] = [
     },
     _meta: {
       requiredScopes: ['read:logs'],
+      readOnly: true,
     },
   },
   {
@@ -58,6 +59,7 @@ export const LOG_TOOLS: Tool[] = [
     },
     _meta: {
       requiredScopes: ['read:logs'],
+      readOnly: true,
     },
   },
 ];

--- a/src/tools/resource-servers.ts
+++ b/src/tools/resource-servers.ts
@@ -36,6 +36,7 @@ export const RESOURCE_SERVER_TOOLS: Tool[] = [
     },
     _meta: {
       requiredScopes: ['read:resource_servers'],
+      readOnly: true,
     },
   },
   {
@@ -50,6 +51,7 @@ export const RESOURCE_SERVER_TOOLS: Tool[] = [
     },
     _meta: {
       requiredScopes: ['read:resource_servers'],
+      readOnly: true,
     },
   },
   {

--- a/src/utils/tools.ts
+++ b/src/utils/tools.ts
@@ -9,13 +9,18 @@ import { Glob } from './glob.js';
  * empty pattern arrays, and pattern matching errors. When readOnly is true,
  * it only returns tools that have _meta.readOnly set to true or tools that follow read-only patterns.
  *
+ * IMPORTANT: The readOnly flag takes priority over pattern matching for security reasons.
+ * Even if patterns match non-read-only tools, when readOnly=true is specified, 
+ * only read-only tools will be returned.
+ *
  * @param allTools - Complete collection of available tools to be filtered
  * @param patterns - Optional glob patterns to filter tools by (e.g., 'auth0*', 'jwt-*')
  *                   If omitted or empty, all tools will be returned
  *                   A single '*' pattern will return all tools
  * @param readOnly - Optional flag to only return read-only tools
  *                   When true, only returns tools marked as readOnly
- * @returns Array of Tool objects that match the specified readOnly criteria
+ *                   Takes priority over pattern matching for security
+ * @returns Array of Tool objects that match the specified criteria
  *          Returns all tools if no patterns provided or on error
  *
  * @example
@@ -23,8 +28,14 @@ import { Glob } from './glob.js';
  * const authTools = getAvailableTools(tools, ['auth*']);
  *
  * @example
- * // Return all read-only tools
+ * // Return all read-only tools (regardless of pattern matching)
  * const readOnlyTools = getAvailableTools(tools, ['*'], true);
+ * 
+ * @example
+ * // Return only read-only tools that match the pattern
+ * // Note: --read-only takes priority, so even if the pattern matches non-read-only tools,
+ * // only the read-only ones will be returned
+ * const readOnlyAuthTools = getAvailableTools(tools, ['auth0_*_application'], true);
  */
 export function getAvailableTools(
   allTools: Tool[],
@@ -40,6 +51,9 @@ export function getAvailableTools(
   }
 
   // Apply read-only filtering if requested
+  // IMPORTANT: This is applied AFTER pattern filtering, ensuring that 
+  // --read-only takes priority over --tools for security
+  // Even if non-read-only tools match the pattern, they will be filtered out here
   if (readOnly) {
     filteredTools = filterToolsByReadOnly(filteredTools);
   }

--- a/src/utils/tools.ts
+++ b/src/utils/tools.ts
@@ -3,16 +3,19 @@ import { log } from './logger.js';
 import { Glob } from './glob.js';
 
 /**
- * Filters the provided tools collection based on specified glob patterns.
+ * Filters the provided tools collection based on specified glob patterns and readOnly flag.
  * This function processes the input patterns against available tools to determine
  * which tools should be returned. It handles special cases like wildcard patterns,
- * empty pattern arrays, and pattern matching errors.
+ * empty pattern arrays, and pattern matching errors. When readOnly is true,
+ * it only returns tools that have _meta.readOnly set to true or tools that follow read-only patterns.
  *
  * @param allTools - Complete collection of available tools to be filtered
  * @param patterns - Optional glob patterns to filter tools by (e.g., 'auth0*', 'jwt-*')
  *                   If omitted or empty, all tools will be returned
  *                   A single '*' pattern will return all tools
- * @returns Array of Tool objects that match the specified patterns
+ * @param readOnly - Optional flag to only return read-only tools
+ *                   When true, only returns tools marked as readOnly
+ * @returns Array of Tool objects that match the specified readOnly criteria
  *          Returns all tools if no patterns provided or on error
  *
  * @example
@@ -20,27 +23,35 @@ import { Glob } from './glob.js';
  * const authTools = getAvailableTools(tools, ['auth*']);
  *
  * @example
- * // Return all tools (either approach works)
- * const allTools1 = getAvailableTools(tools);
- * const allTools2 = getAvailableTools(tools, ['*']);
- *
- * @example
- * // Return tools matching multiple patterns
- * const selectedTools = getAvailableTools(tools, ['auth*', 'jwt-*']);
- *
- * @see {@link validatePatterns} for pattern validation against available tools
- * @see {@link Glob} for the pattern matching implementation
+ * // Return all read-only tools
+ * const readOnlyTools = getAvailableTools(tools, ['*'], true);
  */
-export function getAvailableTools(allTools: Tool[], patterns?: string[]): Tool[] {
-  // Return all tools if no filters specified
-  if (!patterns?.length) {
-    return allTools;
+export function getAvailableTools(
+  allTools: Tool[],
+  patterns?: string[],
+  readOnly?: boolean
+): Tool[] {
+  // Start with all tools
+  let filteredTools = allTools;
+
+  // Apply pattern filtering if patterns are provided
+  if (patterns?.length) {
+    filteredTools = filterToolsByPatterns(filteredTools, patterns);
   }
 
+  // Apply read-only filtering if requested
+  if (readOnly) {
+    filteredTools = filterToolsByReadOnly(filteredTools);
+  }
+
+  return filteredTools;
+}
+
+function filterToolsByPatterns(tools: Tool[], patterns: string[]): Tool[] {
   try {
     // Special case for global wildcard
     if (patterns.length === 1 && patterns[0] === '*') {
-      return allTools;
+      return tools; // Keep all tools, no pattern filtering needed
     }
 
     // Compile glob patterns once for performance
@@ -51,15 +62,13 @@ export function getAvailableTools(allTools: Tool[], patterns?: string[]): Tool[]
     const matchesByPattern = new Map<string, number>();
 
     // For each tool, check if it matches any pattern
-    for (const tool of allTools) {
+    for (const tool of tools) {
       for (const glob of globs) {
         if (glob.matches(tool.name)) {
           enabledToolNames.add(tool.name);
-
           // Count matches per pattern for logging
           const patternString = glob.toString();
           matchesByPattern.set(patternString, (matchesByPattern.get(patternString) || 0) + 1);
-
           // Once we find a match, no need to check other patterns
           break;
         }
@@ -73,18 +82,23 @@ export function getAvailableTools(allTools: Tool[], patterns?: string[]): Tool[]
       }
     }
 
-    // Create the final filtered tool list
-    const availableTools = allTools.filter((tool) => enabledToolNames.has(tool.name));
-    log(`Selected ${availableTools.length} available tools based on patterns`);
-
-    return availableTools;
+    // Create the filtered tool list based on patterns
+    const filteredTools = tools.filter((tool) => enabledToolNames.has(tool.name));
+    log(`Selected ${filteredTools.length} available tools based on patterns`);
+    return filteredTools;
   } catch (error) {
-    // Log error and return all tools as fallback
+    // Log error and use all tools as fallback
     log(
       `Error determining available tools: ${error instanceof Error ? error.message : String(error)}`
     );
-    return allTools;
+    return tools;
   }
+}
+
+function filterToolsByReadOnly(tools: Tool[]): Tool[] {
+  const readOnlyTools = tools.filter((tool) => tool._meta?.readOnly === true);
+  log(`Filtered to ${readOnlyTools.length} read-only tools`);
+  return readOnlyTools;
 }
 
 /**

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -7,6 +7,7 @@ export interface Tool {
   inputSchema?: Record<string, any>;
   _meta?: {
     requiredScopes: string[];
+    readOnly?: boolean;
   };
 }
 
@@ -31,6 +32,7 @@ export interface HandlerResponse {
 // Client Options interface
 export interface ClientOptions {
   tools: string[];
+  readOnly?: boolean;
 }
 
 // Auth0 response interfaces

--- a/test/commands/run.test.ts
+++ b/test/commands/run.test.ts
@@ -110,7 +110,7 @@ describe('Run Module', () => {
 
     expect(startServer).toHaveBeenCalledWith(options);
     expect(logInfo).toHaveBeenCalledWith(
-      'Starting server with read-only tools matching the following pattern(s): auth0_*'
+      'Starting server in read-only mode with tools matching the following pattern(s): auth0_* (--read-only has priority)'
     );
     expect(process.exit).not.toHaveBeenCalled();
   });

--- a/test/commands/run.test.ts
+++ b/test/commands/run.test.ts
@@ -65,7 +65,7 @@ describe('Run Module', () => {
 
     expect(startServer).toHaveBeenCalledWith(options);
     expect(logInfo).toHaveBeenCalledWith(
-      'Starting server with selected tools: auth0_list_applications, auth0_get_application'
+      'Starting server with tools matching the following pattern(s): auth0_list_applications, auth0_get_application'
     );
     expect(process.exit).not.toHaveBeenCalled();
   });
@@ -98,5 +98,33 @@ describe('Run Module', () => {
     vi.mocked(startServer).mockRejectedValue(mockError);
 
     await run({ tools: ['*'] });
+  });
+
+  it('should start the server with read-only option', async () => {
+    const options = {
+      tools: ['auth0_*'],
+      readOnly: true,
+    };
+
+    await run(options);
+
+    expect(startServer).toHaveBeenCalledWith(options);
+    expect(logInfo).toHaveBeenCalledWith(
+      'Starting server with read-only tools matching the following pattern(s): auth0_*'
+    );
+    expect(process.exit).not.toHaveBeenCalled();
+  });
+
+  it('should show read-only mode message when using wildcard with read-only option', async () => {
+    const options = {
+      tools: ['*'],
+      readOnly: true,
+    };
+
+    await run(options);
+
+    expect(startServer).toHaveBeenCalledWith(options);
+    expect(logInfo).toHaveBeenCalledWith('Starting server in read-only mode');
+    expect(process.exit).not.toHaveBeenCalled();
   });
 });

--- a/test/utils/tools.test.ts
+++ b/test/utils/tools.test.ts
@@ -232,5 +232,19 @@ describe('Tool Utilities', () => {
       expect(result.map((t) => t.name)).not.toContain('auth0_create_application');
       expect(result.map((t) => t.name)).not.toContain('auth0_update_application');
     });
+
+    it('should prioritize --read-only flag over --tools when both are specified', () => {
+      // Pattern includes all application tools (including create/update)
+      // But --read-only should take priority and filter out non-read-only tools
+      const result = getAvailableTools(testTools, ['auth0_*_application*'], true);
+      
+      // Should ONLY include read-only tools, even though pattern matched non-read-only tools too
+      expect(result.length).toBeGreaterThan(0);
+      expect(result.every(tool => tool._meta?.readOnly === true)).toBe(true);
+      expect(result.map(t => t.name)).toContain('auth0_list_applications');
+      expect(result.map(t => t.name)).toContain('auth0_get_application');
+      expect(result.map(t => t.name)).not.toContain('auth0_create_application');
+      expect(result.map(t => t.name)).not.toContain('auth0_update_application');
+    });
   });
 });

--- a/test/utils/tools.test.ts
+++ b/test/utils/tools.test.ts
@@ -12,12 +12,52 @@ vi.mock('../../src/utils/logger.js', () => ({
 describe('Tool Utilities', () => {
   // Common test fixtures
   const testTools: Tool[] = [
-    { name: 'auth0_list_applications', description: 'List all applications' },
-    { name: 'auth0_get_application', description: 'Get application details' },
-    { name: 'auth0_create_application', description: 'Create application' },
-    { name: 'auth0_update_application', description: 'Update application' },
-    { name: 'auth0_list_resource_servers', description: 'List resource servers' },
-    { name: 'auth0_get_resource_server', description: 'Get resource server details' },
+    {
+      name: 'auth0_list_applications',
+      description: 'List all applications',
+      _meta: {
+        requiredScopes: ['read:clients'],
+        readOnly: true,
+      },
+    },
+    {
+      name: 'auth0_get_application',
+      description: 'Get application details',
+      _meta: {
+        requiredScopes: ['read:clients'],
+        readOnly: true,
+      },
+    },
+    {
+      name: 'auth0_create_application',
+      description: 'Create application',
+      _meta: {
+        requiredScopes: ['create:clients'],
+      },
+    },
+    {
+      name: 'auth0_update_application',
+      description: 'Update application',
+      _meta: {
+        requiredScopes: ['update:clients'],
+      },
+    },
+    {
+      name: 'auth0_list_resource_servers',
+      description: 'List resource servers',
+      _meta: {
+        requiredScopes: ['read:resource_servers'],
+        readOnly: true,
+      },
+    },
+    {
+      name: 'auth0_get_resource_server',
+      description: 'Get resource server details',
+      _meta: {
+        requiredScopes: ['read:resource_servers'],
+        readOnly: true,
+      },
+    },
   ];
 
   describe('validatePatterns function', () => {
@@ -165,6 +205,32 @@ describe('Tool Utilities', () => {
       // we'll verify that the function doesn't throw even with invalid globs.
       const result = getAvailableTools(testTools, ['[']); // Invalid regex pattern
       expect(result).toBeDefined();
+    });
+
+    it('should filter tools when readOnly is true', () => {
+      const result = getAvailableTools(testTools, undefined, true);
+
+      expect(result).toHaveLength(4);
+      // Should only include list_* and get_* tools
+      expect(result.map((t) => t.name)).toContain('auth0_list_applications');
+      expect(result.map((t) => t.name)).toContain('auth0_get_application');
+      expect(result.map((t) => t.name)).toContain('auth0_list_resource_servers');
+      expect(result.map((t) => t.name)).toContain('auth0_get_resource_server');
+
+      // Should not include create or update tools
+      expect(result.map((t) => t.name)).not.toContain('auth0_create_application');
+      expect(result.map((t) => t.name)).not.toContain('auth0_update_application');
+    });
+
+    it('should apply readOnly filter after pattern filtering', () => {
+      // First filter by applications, then apply readOnly
+      const result = getAvailableTools(testTools, ['auth0_*_application*'], true);
+
+      expect(result).toHaveLength(2);
+      expect(result.map((t) => t.name)).toContain('auth0_list_applications');
+      expect(result.map((t) => t.name)).toContain('auth0_get_application');
+      expect(result.map((t) => t.name)).not.toContain('auth0_create_application');
+      expect(result.map((t) => t.name)).not.toContain('auth0_update_application');
     });
   });
 });


### PR DESCRIPTION
### Changes

This PR adds a new CLI flag `--read-only` that restricts tool access to read-only operations. This implementation:

- Adds new `--read-only` CLI flag to both `init` and `run` commands
- Updates the `_meta` properties of tools to explicitly mark which ones are read-only
- Extends the `getAvailableTools` function to filter by read-only status
- Updates client configurations (Claude, Cursor, Windsurf) to pass the read-only flag
- Adds documentation in `README.md` and provides examples
- Includes comprehensive test coverage for the new functionality

This change improves security by making it convenient and thus easier and thus more likely to limit access to just read operations, which is particularly useful for auditing, exploration, and limiting permissions for certain users or environments.

### References

Please see [here](https://oktawiki.atlassian.net/wiki/spaces/~683180741/pages/3401746543/RFD+Thoughts+on+Auth0+MCP+Server#Tool-Filtering)

### Testing

The changes can be tested by:

- Running the server with the `--read-only` flag: `npx @auth0/auth0-mcp-server run --read-only`
- Verifying that only read-only tools (those with names starting with `auth0_list_` or `auth0_get_`, or marked as `readOnly: true` in their `_meta`) are available
- Combining with existing tool filtering: `npx @auth0/auth0-mcp-server run --tools 'auth0_*_application*' --read-only`

Unit tests have been added to verify:
- The `getAvailableTools` function correctly filters tools based on the readOnly flag
- The tools are properly marked with `readOnly: true` metadata
- The run command correctly passes the readOnly option to the server


- [x] This change adds unit test coverage

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
