### PR TITLE
chore: clean up .prettierignore by removing log files entry

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -7,9 +7,7 @@ coverage/
 # Dependencies
 node_modules/
 
-# Logs
-logs/
-*.log
+
 
 # Environment files
 .env


### PR DESCRIPTION
This pull request makes a minor update to the `.prettierignore` file by removing the exclusion of log files from the Prettier formatting scope.

* [`.prettierignore`](diffhunk://#diff-b640b344ee7f3f03d2a443795a5d0708ef50e2e6e34214109ab2aad13ad6ba98L10-R10): Removed the lines excluding the `logs/` directory and `*.log` files, allowing Prettier to process these files.