### PR TITLE
feat: improve auth token validation for run command

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ To use Auth0 MCP Server with any other MCP Client, you can manually add this con
 
 You can add `--tools '<pattern>'` to the args array to control which tools are available. See [Security Best Practices](#-security-best-practices-for-tool-access) for recommended patterns.
 
-### Authenticate with Auth0
+### Authorize with Auth0
 
 Your browser will automatically open to initiate the OAuth 2.0 device authorization flow. Log into your Auth0 account and grant the requested permissions.
 
@@ -188,7 +188,7 @@ npx @auth0/auth0-mcp-server run --tools 'auth0_list_*,auth0_get_*'
 # Limit to just application-related tools
 npx @auth0/auth0-mcp-server run --tools 'auth0_*_application*'
 
-# Limit to read-only application-related tools 
+# Limit to read-only application-related tools
 # Note: --read-only takes priority when used with --tools
 npx @auth0/auth0-mcp-server run --tools 'auth0_*_application*' --read-only
 
@@ -252,6 +252,8 @@ This will start the device authorization flow, allowing you to log in to your Au
 > - You've logged out from a previous session
 > - You want to switch to a different tenant
 > - Your token has expired
+>
+> The `run` command will automatically check for token validity before starting the server and will provide helpful error messages if authentication is needed.
 
 ### Session Management
 
@@ -357,9 +359,15 @@ To use Auth0 MCP Server with any other MCP Client, you can add this configuratio
 3. **API Errors or Permission Issues**
 
    - Enable debug mode with `export DEBUG=auth0-mcp`
-   - Check your Auth0 token permissions and expiration
+   - Check your Auth0 token status: `npx @auth0/auth0-mcp-server session`
    - Reinitialize with specific scopes: `npx @auth0/auth0-mcp-server init --scopes 'read:*,update:*,create:*'`
    - If a specific operation fails, you may be missing the required scope
+
+4. **Invalid Auth0 Configuration Error**
+
+   - This typically happens when your authorization token is missing or expired
+   - Run `npx @auth0/auth0-mcp-server session` to check your token status
+   - If expired or missing, run `npx @auth0/auth0-mcp-server init` to authenticate
 
 > [!TIP]
 > Most connection issues can be resolved by restarting both the server and Claude Desktop.

--- a/src/auth/device-auth-flow.ts
+++ b/src/auth/device-auth-flow.ts
@@ -234,8 +234,7 @@ export async function getValidAccessToken(): Promise<string | null> {
     const expired = await isTokenExpired();
 
     if (expired) {
-      //[TODO] Implement refresh token flow
-      log('Refresh token flow is not implemented yet, please try npx @auth0/auth0-mcp-server init');
+      log('Token is expired. Please authenticate again using `npx @auth0/auth0-mcp-server init`');
       return null;
     }
 

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -2,6 +2,9 @@ import { startServer } from '../server.js';
 import trackEvent from '../utils/analytics.js';
 import { log, logError, logInfo } from '../utils/logger.js';
 import * as os from 'os';
+import { keychain } from '../utils/keychain.js';
+import { isTokenExpired } from '../auth/device-auth-flow.js';
+import chalk from 'chalk';
 
 /**
  * Command options for the run command
@@ -10,6 +13,54 @@ export interface RunOptions {
   tools: string[];
   readOnly?: boolean;
 }
+
+/**
+ * Validates authorization preconditions before starting the server
+ * @returns {Promise<boolean>} True if authorization is valid, false otherwise
+ */
+const validateAuthorization = async (): Promise<boolean> => {
+  // Check if token exists
+  const token = await keychain.getToken();
+  if (!token) {
+    logError(`${chalk.red('Authorization Error:')} No valid authorization token found`);
+    logError(`${chalk.bold('Recommended actions:')}`);
+    logError(`1. Run ${chalk.cyan('npx @auth0/auth0-mcp-server init')} to authorize with Auth0`);
+    logError(
+      `2. Use ${chalk.cyan('npx @auth0/auth0-mcp-server session')} to check your current session status`
+    );
+    return false;
+  }
+
+  // Check if token is expired
+  const expired = await isTokenExpired();
+  if (expired) {
+    const expiresAt = await keychain.getTokenExpiresAt();
+    const expiryDate = expiresAt ? new Date(expiresAt).toLocaleString() : 'unknown';
+    logError(`${chalk.red('Authorization Error:')} Token has expired (on ${expiryDate})`);
+    logError(`${chalk.bold('Recommended actions:')}`);
+    logError(
+      `1. Run ${chalk.cyan('npx @auth0/auth0-mcp-server init')} to refresh your authorization`
+    );
+    logError(
+      `2. Use ${chalk.cyan('npx @auth0/auth0-mcp-server session')} to check your current session details`
+    );
+    return false;
+  }
+
+  // Check if domain exists
+  const domain = await keychain.getDomain();
+  if (!domain) {
+    logError(`${chalk.red('Authorization Error:')} No Auth0 domain found in configuration`);
+    logError(`${chalk.bold('Recommended actions:')}`);
+    logError(`1. Run ${chalk.cyan('npx @auth0/auth0-mcp-server init')} to authorize with Auth0`);
+    logError(
+      `2. Use ${chalk.cyan('npx @auth0/auth0-mcp-server session')} to check your current configuration`
+    );
+    return false;
+  }
+
+  return true;
+};
 
 /**
  * Main function to start server
@@ -25,6 +76,13 @@ const run = async (options: RunOptions): Promise<void> => {
     }
 
     trackEvent.trackServerRun();
+
+    // Validate authorization before starting server
+    const isAuthorized = await validateAuthorization();
+    if (!isAuthorized) {
+      // Exit with code 1 (standard error code)
+      process.exit(1);
+    }
 
     if (options.readOnly && options.tools.length === 1 && options.tools[0] === '*') {
       logInfo('Starting server in read-only mode');

--- a/src/tools/actions.ts
+++ b/src/tools/actions.ts
@@ -233,7 +233,7 @@ export const ACTION_HANDLERS: Record<
       // Check for token
       if (!request.token) {
         log('Warning: Token is empty or undefined');
-        return createErrorResponse('Error: Missing authentication token');
+        return createErrorResponse('Error: Missing authorization token');
       }
 
       // Check if domain is configured
@@ -371,7 +371,7 @@ export const ACTION_HANDLERS: Record<
       // Check for token
       if (!request.token) {
         log('Warning: Token is empty or undefined');
-        return createErrorResponse('Error: Missing authentication token');
+        return createErrorResponse('Error: Missing authorization token');
       }
 
       // Check if domain is configured
@@ -457,7 +457,7 @@ export const ACTION_HANDLERS: Record<
       // Check for token
       if (!request.token) {
         log('Warning: Token is empty or undefined');
-        return createErrorResponse('Error: Missing authentication token');
+        return createErrorResponse('Error: Missing authorization token');
       }
 
       // Check if domain is configured
@@ -544,7 +544,7 @@ export const ACTION_HANDLERS: Record<
       // Check for token
       if (!request.token) {
         log('Warning: Token is empty or undefined');
-        return createErrorResponse('Error: Missing authentication token');
+        return createErrorResponse('Error: Missing authorization token');
       }
 
       // Check if domain is configured
@@ -616,7 +616,7 @@ export const ACTION_HANDLERS: Record<
       // Check for token
       if (!request.token) {
         log('Warning: Token is empty or undefined');
-        return createErrorResponse('Error: Missing authentication token');
+        return createErrorResponse('Error: Missing authorization token');
       }
 
       // Check if domain is configured

--- a/src/tools/applications.ts
+++ b/src/tools/applications.ts
@@ -254,7 +254,7 @@ export const APPLICATION_HANDLERS: Record<
     try {
       if (!request.token) {
         log('Warning: Token is missing');
-        return createErrorResponse('Error: Missing authentication token');
+        return createErrorResponse('Error: Missing authorization token');
       }
 
       // Check if domain is configured
@@ -378,7 +378,7 @@ export const APPLICATION_HANDLERS: Record<
       // Check for token
       if (!request.token) {
         log('Warning: Token is empty or undefined');
-        return createErrorResponse('Error: Missing authentication token');
+        return createErrorResponse('Error: Missing authorization token');
       }
 
       // Check if domain is configured
@@ -490,7 +490,7 @@ export const APPLICATION_HANDLERS: Record<
       // Check for token
       if (!request.token) {
         log('Warning: Token is empty or undefined');
-        return createErrorResponse('Error: Missing authentication token');
+        return createErrorResponse('Error: Missing authorization token');
       }
 
       // Check if domain is configured
@@ -710,7 +710,7 @@ export const APPLICATION_HANDLERS: Record<
       // Check for token
       if (!request.token) {
         log('Warning: Token is empty or undefined');
-        return createErrorResponse('Error: Missing authentication token');
+        return createErrorResponse('Error: Missing authorization token');
       }
 
       // Check if domain is configured

--- a/src/tools/forms.ts
+++ b/src/tools/forms.ts
@@ -153,7 +153,7 @@ export const FORM_HANDLERS: Record<
       // Check for token
       if (!request.token) {
         log('Warning: Token is empty or undefined');
-        return createErrorResponse('Error: Missing authentication token');
+        return createErrorResponse('Error: Missing authorization token');
       }
 
       // Check if domain is configured
@@ -246,7 +246,7 @@ export const FORM_HANDLERS: Record<
       // Check for token
       if (!request.token) {
         log('Warning: Token is empty or undefined');
-        return createErrorResponse('Error: Missing authentication token');
+        return createErrorResponse('Error: Missing authorization token');
       }
 
       // Check if domain is configured
@@ -310,7 +310,7 @@ export const FORM_HANDLERS: Record<
       // Check for token
       if (!request.token) {
         log('Warning: Token is empty or undefined');
-        return createErrorResponse('Error: Missing authentication token');
+        return createErrorResponse('Error: Missing authorization token');
       }
 
       // Check if domain is configured
@@ -391,7 +391,7 @@ export const FORM_HANDLERS: Record<
       // Check for token
       if (!request.token) {
         log('Warning: Token is empty or undefined');
-        return createErrorResponse('Error: Missing authentication token');
+        return createErrorResponse('Error: Missing authorization token');
       }
 
       // Check if domain is configured

--- a/src/tools/logs.ts
+++ b/src/tools/logs.ts
@@ -77,7 +77,7 @@ export const LOG_HANDLERS: Record<
       // Check for token
       if (!request.token) {
         log('Warning: Token is empty or undefined');
-        return createErrorResponse('Error: Missing authentication token');
+        return createErrorResponse('Error: Missing authorization token');
       }
 
       // Check if domain is configured
@@ -186,7 +186,7 @@ export const LOG_HANDLERS: Record<
       // Check for token
       if (!request.token) {
         log('Warning: Token is empty or undefined');
-        return createErrorResponse('Error: Missing authentication token');
+        return createErrorResponse('Error: Missing authorization token');
       }
 
       // Check if domain is configured

--- a/src/tools/resource-servers.ts
+++ b/src/tools/resource-servers.ts
@@ -222,7 +222,7 @@ export const RESOURCE_SERVER_HANDLERS: Record<
     try {
       if (!request.token) {
         log('Warning: Token is missing');
-        return createErrorResponse('Error: Missing authentication token');
+        return createErrorResponse('Error: Missing authorization token');
       }
 
       // Check if domain is configured
@@ -366,7 +366,7 @@ export const RESOURCE_SERVER_HANDLERS: Record<
       // Check for token
       if (!request.token) {
         log('Warning: Token is empty or undefined');
-        return createErrorResponse('Error: Missing authentication token');
+        return createErrorResponse('Error: Missing authorization token');
       }
 
       // Check if domain is configured
@@ -453,7 +453,7 @@ export const RESOURCE_SERVER_HANDLERS: Record<
       // Check for token
       if (!request.token) {
         log('Warning: Token is empty or undefined');
-        return createErrorResponse('Error: Missing authentication token');
+        return createErrorResponse('Error: Missing authorization token');
       }
 
       // Check if domain is configured
@@ -566,7 +566,7 @@ export const RESOURCE_SERVER_HANDLERS: Record<
       // Check for token
       if (!request.token) {
         log('Warning: Token is empty or undefined');
-        return createErrorResponse('Error: Missing authentication token');
+        return createErrorResponse('Error: Missing authorization token');
       }
 
       // Check if domain is configured

--- a/src/utils/tools.ts
+++ b/src/utils/tools.ts
@@ -10,7 +10,7 @@ import { Glob } from './glob.js';
  * it only returns tools that have _meta.readOnly set to true or tools that follow read-only patterns.
  *
  * IMPORTANT: The readOnly flag takes priority over pattern matching for security reasons.
- * Even if patterns match non-read-only tools, when readOnly=true is specified, 
+ * Even if patterns match non-read-only tools, when readOnly=true is specified,
  * only read-only tools will be returned.
  *
  * @param allTools - Complete collection of available tools to be filtered
@@ -30,7 +30,7 @@ import { Glob } from './glob.js';
  * @example
  * // Return all read-only tools (regardless of pattern matching)
  * const readOnlyTools = getAvailableTools(tools, ['*'], true);
- * 
+ *
  * @example
  * // Return only read-only tools that match the pattern
  * // Note: --read-only takes priority, so even if the pattern matches non-read-only tools,
@@ -51,7 +51,7 @@ export function getAvailableTools(
   }
 
   // Apply read-only filtering if requested
-  // IMPORTANT: This is applied AFTER pattern filtering, ensuring that 
+  // IMPORTANT: This is applied AFTER pattern filtering, ensuring that
   // --read-only takes priority over --tools for security
   // Even if non-read-only tools match the pattern, they will be filtered out here
   if (readOnly) {

--- a/test/commands/run.test.ts
+++ b/test/commands/run.test.ts
@@ -1,8 +1,10 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import run from '../../src/commands/run.js';
 import { startServer } from '../../src/server';
-import { log, logInfo } from '../../src/utils/logger';
+import { log, logInfo, logError } from '../../src/utils/logger';
 import * as os from 'os';
+import { keychain } from '../../src/utils/keychain.js';
+import { isTokenExpired } from '../../src/auth/device-auth-flow.js';
 
 // Mock dependencies first, before any imports
 vi.mock('../../src/utils/logger', () => ({
@@ -23,6 +25,18 @@ vi.mock('os', () => ({
   homedir: vi.fn().mockReturnValue('/mock/home/dir'),
 }));
 
+vi.mock('../../src/utils/keychain.js', () => ({
+  keychain: {
+    getToken: vi.fn().mockResolvedValue('mock-token'),
+    getDomain: vi.fn().mockResolvedValue('mock-domain.auth0.com'),
+    getTokenExpiresAt: vi.fn().mockResolvedValue(Date.now() + 3600000), // 1 hour from now
+  },
+}));
+
+vi.mock('../../src/auth/device-auth-flow.js', () => ({
+  isTokenExpired: vi.fn().mockResolvedValue(false),
+}));
+
 describe('Run Module', () => {
   const originalExit = process.exit;
   const originalConsoleError = console.error;
@@ -39,6 +53,12 @@ describe('Run Module', () => {
 
     // Restore original environment
     process.env = { ...originalEnv };
+
+    // Setup default keychain mock values
+    vi.mocked(keychain.getToken).mockResolvedValue('mock-token');
+    vi.mocked(keychain.getDomain).mockResolvedValue('mock-domain.auth0.com');
+    vi.mocked(keychain.getTokenExpiresAt).mockResolvedValue(Date.now() + 3600000);
+    vi.mocked(isTokenExpired).mockResolvedValue(false);
   });
 
   afterEach(() => {
@@ -126,5 +146,61 @@ describe('Run Module', () => {
     expect(startServer).toHaveBeenCalledWith(options);
     expect(logInfo).toHaveBeenCalledWith('Starting server in read-only mode');
     expect(process.exit).not.toHaveBeenCalled();
+  });
+
+  describe('Authorization Validation', () => {
+    it('should exit if no token is found', async () => {
+      vi.mocked(keychain.getToken).mockResolvedValue(null);
+
+      // We need to mock process.exit to prevent the test from exiting
+      // but also to make sure our test waits for the code to finish
+      const processExitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+        throw new Error('Process exit called');
+      });
+
+      // Run the command and expect it to call process.exit
+      await expect(run({ tools: ['*'] })).rejects.toThrow('Process exit called');
+
+      expect(logError).toHaveBeenCalledWith(expect.stringContaining('Authorization Error:'));
+      expect(processExitSpy).toHaveBeenCalledWith(1);
+      expect(startServer).not.toHaveBeenCalled();
+    });
+
+    it('should exit if token is expired', async () => {
+      vi.mocked(isTokenExpired).mockResolvedValue(true);
+      vi.mocked(keychain.getTokenExpiresAt).mockResolvedValue(Date.now() - 3600000); // 1 hour ago
+
+      // We need to mock process.exit to prevent the test from exiting
+      // but also to make sure our test waits for the code to finish
+      const processExitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+        throw new Error('Process exit called');
+      });
+
+      // Run the command and expect it to call process.exit
+      await expect(run({ tools: ['*'] })).rejects.toThrow('Process exit called');
+
+      expect(logError).toHaveBeenCalledWith(expect.stringContaining('Authorization Error:'));
+      expect(processExitSpy).toHaveBeenCalledWith(1);
+      expect(startServer).not.toHaveBeenCalled();
+    });
+
+    it('should exit if no domain is found', async () => {
+      vi.mocked(keychain.getToken).mockResolvedValue('mock-token');
+      vi.mocked(isTokenExpired).mockResolvedValue(false);
+      vi.mocked(keychain.getDomain).mockResolvedValue(null);
+
+      // We need to mock process.exit to prevent the test from exiting
+      // but also to make sure our test waits for the code to finish
+      const processExitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+        throw new Error('Process exit called');
+      });
+
+      // Run the command and expect it to call process.exit
+      await expect(run({ tools: ['*'] })).rejects.toThrow('Process exit called');
+
+      expect(logError).toHaveBeenCalledWith(expect.stringContaining('Authorization Error:'));
+      expect(processExitSpy).toHaveBeenCalledWith(1);
+      expect(startServer).not.toHaveBeenCalled();
+    });
   });
 });

--- a/test/tools/actions.test.ts
+++ b/test/tools/actions.test.ts
@@ -104,7 +104,7 @@ describe('Actions Tool Handlers', () => {
       const response = await ACTION_HANDLERS.auth0_list_actions(request, config);
 
       expect(response.isError).toBe(true);
-      expect(response.content[0].text).toContain('Missing authentication token');
+      expect(response.content[0].text).toContain('Missing authorization token');
     });
 
     it('should handle missing domain', async () => {

--- a/test/tools/forms.test.ts
+++ b/test/tools/forms.test.ts
@@ -103,7 +103,7 @@ describe('Forms Tool Handlers', () => {
       const response = await FORM_HANDLERS.auth0_list_forms(request, config);
 
       expect(response.isError).toBe(true);
-      expect(response.content[0].text).toContain('Missing authentication token');
+      expect(response.content[0].text).toContain('Missing authorization token');
     });
 
     it('should handle missing domain', async () => {

--- a/test/tools/resource-servers.test.ts
+++ b/test/tools/resource-servers.test.ts
@@ -108,7 +108,7 @@ describe('Resource Servers Tool Handlers', () => {
       const response = await RESOURCE_SERVER_HANDLERS.auth0_list_resource_servers(request, config);
 
       expect(response.isError).toBe(true);
-      expect(response.content[0].text).toContain('Missing authentication token');
+      expect(response.content[0].text).toContain('Missing authorization token');
     });
 
     it('should handle missing domain', async () => {

--- a/test/utils/tools.test.ts
+++ b/test/utils/tools.test.ts
@@ -237,14 +237,14 @@ describe('Tool Utilities', () => {
       // Pattern includes all application tools (including create/update)
       // But --read-only should take priority and filter out non-read-only tools
       const result = getAvailableTools(testTools, ['auth0_*_application*'], true);
-      
+
       // Should ONLY include read-only tools, even though pattern matched non-read-only tools too
       expect(result.length).toBeGreaterThan(0);
-      expect(result.every(tool => tool._meta?.readOnly === true)).toBe(true);
-      expect(result.map(t => t.name)).toContain('auth0_list_applications');
-      expect(result.map(t => t.name)).toContain('auth0_get_application');
-      expect(result.map(t => t.name)).not.toContain('auth0_create_application');
-      expect(result.map(t => t.name)).not.toContain('auth0_update_application');
+      expect(result.every((tool) => tool._meta?.readOnly === true)).toBe(true);
+      expect(result.map((t) => t.name)).toContain('auth0_list_applications');
+      expect(result.map((t) => t.name)).toContain('auth0_get_application');
+      expect(result.map((t) => t.name)).not.toContain('auth0_create_application');
+      expect(result.map((t) => t.name)).not.toContain('auth0_update_application');
     });
   });
 });


### PR DESCRIPTION
### Changes

This PR improves the authentication validation in the `run` command to provide better user experience when tokens are missing or expired:

- Added precondition checks to validate token presence and expiration before starting server
- Added helpful error messages with structured recommendations when auth fails
- Used colored and formatted output with clear "Authorization Error" headings
- Return non-zero exit code (1) for authorization errors
- Added comprehensive tests for all validation scenarios
- Updated README with new validation information

This change helps users quickly understand and resolve authentication issues instead of seeing cryptic errors:
```
[ERROR:auth0-mcp] Authorization Error: No valid authentication token found
[ERROR:auth0-mcp] Recommended actions:
[ERROR:auth0-mcp] 1. Run npx @auth0/auth0-mcp-server init to authenticate with Auth0
[ERROR:auth0-mcp] 2. Use npx @auth0/auth0-mcp-server session to check your current session status
```

### Testing

- Manually tested to verify the new error messages appear correctly when token is missing or expired
- Added unit tests for all validation scenarios that verify:
  - The correct error messages are displayed
  - The process exits with code 1
  - The server doesn't start when validation fails

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors