### PR TITLE
chore: Clean up .prettierignore by removing log files entry

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -7,9 +7,7 @@ coverage/
 # Dependencies
 node_modules/
 
-# Logs
-logs/
-*.log
+
 
 # Environment files
 .env


### PR DESCRIPTION
### Changes

This PR removes the logs/ directory and *.log files from the .prettierignore file as they are not needed for this project. This helps maintain a cleaner configuration.

### Testing

The change was manually verified by making sure that logs are not part of the repository's structure, and thus don't need to be ignored by Prettier.

### Checklist

- [x] I have read the [Auth0 general contribution guidelines]
- [x] I have read the [Auth0 Code of Conduct]
- [x] All existing and new tests complete without errors
