### PR TITLE
chore: add glama.json to claim ownership

### DIFF
--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": [
+    "gyaneshgouraw-okta",
+    "kushalshit27"
+  ]
+}


### PR DESCRIPTION
### Changes

Added glama.json file to the root of the repository to claim ownership of the MCP Server on Glama.ai. This file specifies GitHub maintainers who have permission to maintain the server.

### References

Glama.ai instructions for claiming MCP server ownership: https://glama.ai/mcp/servers/@auth0/auth0-mcp-server

### Testing

No testing required as this is a metadata file that doesn't affect functionality.

- [ ] This change adds unit test coverage
- [ ] This change adds integration test coverage

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors