### PR TITLE
docs: add DeepWiki badge to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![Node.js Version](https://img.shields.io/badge/node-%3E%3D18.0.0-brightgreen.svg)](https://nodejs.org/)
 [![NPM Downloads](https://img.shields.io/npm/dw/%40auth0%2Fauth0-mcp-server)](https://www.npmjs.com/package/@auth0/auth0-mcp-server)
 [![NPM Version](https://img.shields.io/npm/v/@auth0/auth0-mcp-server)](https://www.npmjs.com/package/@auth0/auth0-mcp-server)
+[<img src="https://devin.ai/assets/deepwiki-badge.png" alt="Ask questions about auth0-mcp-server on DeepWiki" height="20"/>](https://deepwiki.com/auth0/auth0-mcp-server)
 
 </div>
 


### PR DESCRIPTION
### Changes

Add DeepWiki badge to README.md for easy access to project documentation on DeepWiki.com. This allows users to quickly access contextual information about the repository through DeepWiki's AI-powered documentation platform.

### References

N/A - Simple documentation improvement.

### Testing

This change can be verified by checking the README.md preview in the PR to ensure the badge is correctly displayed with proper formatting and links to https://deepwiki.com/auth0/auth0-mcp-server.

- [ ] This change adds unit test coverage
- [ ] This change adds integration test coverage

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors