### PR TITLE
fix: add item type definition for authorization_details in resource server tools

### DIFF
--- a/src/tools/resource-servers.ts
+++ b/src/tools/resource-servers.ts
@@ -134,6 +134,9 @@ export const RESOURCE_SERVER_TOOLS: Tool[] = [
         authorization_details: {
           type: 'array',
           description: 'Authorization details for the resource server.',
+          items: {
+            type: 'object'
+          },
         },
         proof_of_possession: {
           type: 'object',
@@ -218,6 +221,9 @@ export const RESOURCE_SERVER_TOOLS: Tool[] = [
         authorization_details: {
           type: 'array',
           description: 'Authorization details for the resource server.',
+          items: {
+            type: 'object'
+          },
         },
         proof_of_possession: {
           type: 'object',


### PR DESCRIPTION
### 🛠️ Changes

- Added missing items property to the `authorization_details` array schema in both resource server tools:
- Fixed in `auth0_create_resource_server` definition
- Fixed in `auth0_update_resource_server` definition
- Kept schema definition minimal using items: { type: 'object' } without additional constraints
- Ensured consistency across both tool definitions

### 🧪 Testing

- Verified schema passes validation by the MCP server
- Confirmed resource server creation with authorization details succeeds
- Validated that authorization details can be properly sent in API requests

### 💥 Impact

- Eliminates validation errors when creating/updating resource servers with authorization details
- Ensures backward compatibility with existing API consumers
- No change to runtime behavior - only fixes schema validation
- Allows customers to continue using the authorization details feature without interruption