### PR TITLE
Fix npm publish tag logic for beta versions

### DIFF
--- a/.github/actions/npm-publish/action.yml
+++ b/.github/actions/npm-publish/action.yml
@@ -40,7 +40,7 @@ runs:
       working-directory: ${{ inputs.release-directory }}
       run: |
         if [[ "${VERSION}" == *"beta"* ]]; then
-          TAG="beta"
+          TAG="latest"
         elif [[ "${VERSION}" == *"alpha"* ]]; then
           TAG="alpha"
         else


### PR DESCRIPTION
## Description

This PR fixes the npm publish tag logic for beta versions in the GitHub Actions workflow.

## Changes

- This ensures that beta releases are tagged as `latest` in the npm registry 
## Impact


- Improves npm package management and user experience

## Testing

- [ ] Verified the conditional logic is correct
- [ ] Confirmed this aligns with npm tagging best practices