### PR TITLE
chore: update npm publish action and add dependabot configuration

### DIFF
--- a/.github/actions/npm-publish/action.yml
+++ b/.github/actions/npm-publish/action.yml
@@ -3,8 +3,6 @@ name: Publish release to npm
 inputs:
   node-version:
     required: true
-  npm-token:
-    required: true
   version:
     required: true
   require-build:
@@ -26,6 +24,10 @@ runs:
         cache: 'npm'
         registry-url: 'https://registry.npmjs.org'
 
+    - name: Update npm
+      shell: bash
+      run: npm install -g npm@11
+
     - name: Install dependencies
       shell: bash
       run: npm ci --include=dev
@@ -46,7 +48,6 @@ runs:
         else
           TAG="latest"
         fi
-        npm publish --provenance --tag $TAG
+        npm publish --tag $TAG
       env:
-        NODE_AUTH_TOKEN: ${{ inputs.npm-token }}
         VERSION: ${{ inputs.version }}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]

--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -15,8 +15,6 @@ on:
     secrets:
       github-token:
         required: true
-      npm-token:
-        required: true
 
 ### TODO: Replace instances of './.github/actions/' w/ `auth0/dx-sdk-actions/` and append `@latest` after the common `dx-sdk-actions` repo is made public.
 ### TODO: Also remove `get-prerelease`, `get-version`, `release-create`, `tag-create` and `tag-exists` actions from this repo's .github/actions folder once the repo is public.
@@ -26,6 +24,9 @@ jobs:
     if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.merged && startsWith(github.event.pull_request.head.ref, 'release/'))
     runs-on: ubuntu-latest
     environment: release
+    permissions:
+      contents: write
+      id-token: write
 
     steps:
       # Checkout the code
@@ -70,7 +71,6 @@ jobs:
           require-build: ${{ inputs.require-build }}
           release-directory: ${{ inputs.release-directory }}
           version: ${{ steps.get_version.outputs.version }}
-          npm-token: ${{ secrets.npm-token }}
 
       # Create a release for the tag
       - uses: ./.github/actions/release-create

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,8 +31,7 @@ jobs:
   release:
     uses: ./.github/workflows/npm-release.yml
     with:
-      node-version: 18
+      node-version: 22
       require-build: true
     secrets:
-      npm-token: ${{ secrets.NPM_TOKEN }}
       github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Switch npm publishing to use OIDC trusted publishing instead of NPM_TOKEN secret
- Upgrade Node.js version from 18 to 22 for release workflow
- Add Dependabot configuration for automated dependency updates

## Changes

### OIDC Trusted Publishing
- Remove `npm-token` input from npm-publish action and npm-release workflow
- Add `id-token: write` permission to enable OIDC token generation
- Remove `--provenance` flag and `NODE_AUTH_TOKEN` env var (OIDC handles authentication)

### Build Improvements
- Upgrade Node.js from v18 to v22 in release workflow
- Add npm v11 upgrade step in publish action for better compatibility

### Dependabot
- Add `.github/dependabot.yml` to automate dependency updates
- Configure daily checks for both GitHub Actions and npm dependencies
- Ignore major version updates for npm packages to prevent breaking changes

## Test plan

- [ ] Verify release workflow triggers correctly on release branch merge
- [ ] Confirm npm publish succeeds with OIDC authentication
- [ ] Validate Dependabot creates PRs for dependency updates

