### PR TITLE
feat: add initial server configuration

### DIFF
--- a/server.json
+++ b/server.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "com.auth0/mcp",
+  "title": "Auth0 MCP Server",
+  "description": "Auth0 MCP Server: Manage Auth0 applications, APIs, actions, logs, and forms using natural language",
+  "repository": {
+    "url": "https://github.com/auth0/auth0-mcp-server",
+    "source": "github"
+  },
+  "websiteUrl": "https://github.com/auth0/auth0-mcp-server#readme",
+  "version": "0.1.0-beta.10",
+  "license": "MIT",
+  "packages": [
+    {
+      "registryType": "npm",
+      "identifier": "@auth0/auth0-mcp-server",
+      "registryBaseUrl": "https://registry.npmjs.org",
+      "version": "0.1.0-beta.10",
+      "runtimeHint": "npx",
+      "transport": {
+        "type": "stdio"
+      },
+      "runtimeArguments": [
+        {
+          "type": "positional",
+          "value": "-y"
+        }
+      ],
+      "packageArguments": [
+        {
+          "type": "positional",
+          "value": "run"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Adds the server.json for the MCP [registry](https://registry.modelcontextprotocol.io/?q=com.auth0%2Fmcp)

<img width="429" height="457" alt="mcp" src="https://github.com/user-attachments/assets/a441bf6f-2c55-401d-81a0-4b2d64698276" />
