### PR TITLE
fix: release CI

### DIFF
--- a/.github/actions/npm-publish/action.yml
+++ b/.github/actions/npm-publish/action.yml
@@ -21,7 +21,7 @@ runs:
       uses: actions/setup-node@v4
       with:
         node-version: ${{ inputs.node-version }}
-        cache: 'npm'
+        package-manager-cache: false
         registry-url: 'https://registry.npmjs.org'
 
     - name: Update npm


### PR DESCRIPTION
### Changes

This pull request makes a minor update to the npm publish GitHub Action configuration. The change disables the automatic package manager cache by setting `package-manager-cache` to `false`, which may help avoid caching issues during the publish process.

### References

- fix: https://github.com/auth0/auth0-mcp-server/actions/runs/24348666253?pr=146

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

- [ ] This change adds unit test coverage
- [ ] This change adds integration test coverage

### Checklist

- [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [ ] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [ ] All existing and new tests complete without errors
