### PR TITLE
fix: release CI

### DIFF
--- a/.github/actions/npm-publish/action.yml
+++ b/.github/actions/npm-publish/action.yml
@@ -15,10 +15,10 @@ runs:
 
   steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Setup Node
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: ${{ inputs.node-version }}
         package-manager-cache: false
@@ -26,7 +26,7 @@ runs:
 
     - name: Update npm
       shell: bash
-      run: npm install -g npm@11
+      run: npm install -g "npm@11.11.0"
 
     - name: Install dependencies
       shell: bash

--- a/.github/actions/npm-publish/action.yml
+++ b/.github/actions/npm-publish/action.yml
@@ -21,7 +21,7 @@ runs:
       uses: actions/setup-node@v4
       with:
         node-version: ${{ inputs.node-version }}
-        cache: 'npm'
+        package-manager-cache: false
         registry-url: 'https://registry.npmjs.org'
 
     - name: Update npm


### PR DESCRIPTION
### Changes
This pull request updates the `.github/actions/npm-publish/action.yml` workflow to use the latest major versions of its dependencies and pins the `npm` version more precisely. These changes help ensure better compatibility, security, and reproducibility in the CI/CD process.

Dependency and workflow updates:

* Updated the `actions/checkout` action from version `v4` to `v6` for improved features and security.
* Updated the `actions/setup-node` action from version `v4` to `v6` to use the latest Node.js setup improvements.
* Changed the `npm` installation step to pin the version to `11.11.0` instead of just `11`, ensuring consistent builds.

### References

fix: [auth0/auth0-mcp-server/actions/runs/24348666253?pr=146](https://github.com/auth0/auth0-mcp-server/actions/runs/24348666253?pr=146)

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

- [ ] This change adds unit test coverage
- [ ] This change adds integration test coverage

### Checklist

- [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [ ] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [ ] All existing and new tests complete without errors
