### PR TITLE
[DXAA-554] Add callback url resolver utility for future onboarding tool

### DIFF
--- a/src/utils/onboarding.ts
+++ b/src/utils/onboarding.ts
@@ -1,0 +1,140 @@
+import { readFile } from "fs/promises";
+import { join } from "path";
+
+export interface QuickstartSpec {
+    defaultAppOrigin: string;
+    callbackPath: string;
+    logoutPath: string;
+}
+
+export enum UrlSource {
+    Explicit = "explicit",
+    ProjectConfig = "project_config",
+    FrameWorkDefault = "framework_default"
+}
+
+export interface ResolvedCallbackUrls {
+    base_url: string;
+    callback_urls: string[];
+    logout_urls: string[];
+    web_origins: string[];
+    url_source: UrlSource
+}
+
+// Port Detection Helpers
+
+const readJsonFile = async (filePath: string) => {
+    try {
+        const content = await readTextFile(filePath);
+        return content ? JSON.parse(content) : null;
+    } catch {
+        return null;
+    }
+}
+
+const readTextFile = async (filePath: string) => {
+    try {
+        return await readFile(filePath, "utf-8");
+    } catch {
+        return null;
+    }
+}
+
+const extractPortFromDevScript = (packageJson: any): number | null => {
+    const devScript = packageJson?.scripts?.dev ?? packageJson?.scripts?.start;
+    if (typeof devScript !== "string") return null;
+
+    const match = devScript.match(/(?:-p|--port)\s+(\d+)/);
+    return match ? parseInt(match[1], 10) : null;
+}
+
+async function detectPortFromViteConfig(projectPath: string): Promise<number | null> {
+    for (const filename of ['vite.config.ts', 'vite.config.js', 'vite.config.mts', 'vite.config.mjs']) {
+      const content = await readTextFile(join(projectPath, filename));
+      if (!content) continue;
+
+      const match = content.match(/server\s*:\s*\{[^}]*port\s*:\s*(\d+)/s);
+      if (match) return parseInt(match[1], 10);
+    }
+    return null;
+  }
+
+async function detectPortFromAngularJson(projectPath: string): Promise<number | null> {
+    const angularJson = await readJsonFile(join(projectPath, 'angular.json'));
+    if (!angularJson) return null;
+
+    const projects = angularJson.projects ?? {};
+    for (const project of Object.values(projects) as any[]) {
+      const port = project?.architect?.serve?.options?.port;
+      if (typeof port === 'number') return port;
+    }
+    return null;
+  }
+
+  async function detectPortFromProject(projectPath: string): Promise<number | null> {
+    // Try package.json dev script first
+    const packageJson = await readJsonFile(join(projectPath, 'package.json'));
+    if (packageJson) {
+      const port = extractPortFromDevScript(packageJson);
+      if (port) return port;
+    }
+
+    // Try vite config
+    const vitePort = await detectPortFromViteConfig(projectPath);
+    if (vitePort) return vitePort;
+
+    // Try angular.json
+    const angularPort = await detectPortFromAngularJson(projectPath);
+    if (angularPort) return angularPort;
+
+    return null;
+  }
+
+  function replacePort(baseUrl: string, port: number): string {
+    const url = new URL(baseUrl);
+    url.port = String(port);
+    return url.origin;
+  }
+
+export const resolveCallbackUrls = async (
+    projectPath: string | undefined, 
+    quickstartSpec: QuickstartSpec,
+    explicitBaseUrl?: string
+): Promise<ResolvedCallbackUrls> => {
+    let baseUrl: string;
+    let urlSource: UrlSource;
+    // TODO: Add tests for this to ensure white spaces and slashes are removed
+    if (explicitBaseUrl) {
+        baseUrl = explicitBaseUrl.trim().replace(/\/+$/, "");
+        urlSource = UrlSource.Explicit;
+    } else if (projectPath) {
+        const detectedPort = await detectPortFromProject(projectPath);
+
+        if (detectedPort) {
+            baseUrl = replacePort(quickstartSpec.defaultAppOrigin, detectedPort);
+            urlSource = UrlSource.ProjectConfig;
+        } else {
+            baseUrl = quickstartSpec.defaultAppOrigin
+            urlSource = UrlSource.FrameWorkDefault;
+        }
+    } else {
+        baseUrl = quickstartSpec.defaultAppOrigin;
+        urlSource = UrlSource.FrameWorkDefault;
+    }
+
+    const callbackUrl = quickstartSpec.callbackPath
+        ? `${baseUrl}${quickstartSpec.callbackPath}`
+        : baseUrl;
+    
+    const logoutUrl = quickstartSpec.logoutPath
+        ? `${baseUrl}${quickstartSpec.logoutPath}`
+        : baseUrl;
+    
+    return {
+        base_url: baseUrl,
+        callback_urls: [callbackUrl],
+        logout_urls: [logoutUrl],
+        web_origins: [baseUrl],
+        url_source: urlSource,
+    }
+} 

--- a/src/utils/onboarding.ts
+++ b/src/utils/onboarding.ts
@@ -1,140 +1,46 @@
-import { readFile } from "fs/promises";
-import { join } from "path";
-
-export interface QuickstartSpec {
-    defaultAppOrigin: string;
-    callbackPath: string;
-    logoutPath: string;
-}
+import { QuickstartSpec, QuickstartAppType } from './types';
 
 export enum UrlSource {
-    Explicit = "explicit",
-    ProjectConfig = "project_config",
-    FrameWorkDefault = "framework_default"
+  Detected = 'detected',
+  FrameworkDefault = 'framework_default',
 }
 
 export interface ResolvedCallbackUrls {
-    base_url: string;
-    callback_urls: string[];
-    logout_urls: string[];
-    web_origins: string[];
-    url_source: UrlSource
+  base_url: string;
+  callback_urls?: string[];
+  logout_urls?: string[];
+  web_origins?: string[];
+  url_source: UrlSource;
 }
 
-// Port Detection Helpers
+const APP_TYPE_URL_CONFIGS: Record<QuickstartAppType, Set<string>> = {
+  spa: new Set(['callback_urls', 'logout_urls', 'web_origins']),
+  webapp: new Set(['callback_urls', 'logout_urls']),
+  native: new Set(['callback_urls', 'logout_urls']),
+};
 
-const readJsonFile = async (filePath: string) => {
-    try {
-        const content = await readTextFile(filePath);
-        return content ? JSON.parse(content) : null;
-    } catch {
-        return null;
-    }
-}
+export const resolveCallbackUrls = (quickstartSpec: QuickstartSpec, baseUrl?: string) => {
+  const resolvedBaseUrl = baseUrl
+    ? baseUrl.trim().replace(/\/+$/, '')
+    : quickstartSpec.defaultAppOrigin;
 
-const readTextFile = async (filePath: string) => {
-    try {
-        return await readFile(filePath, "utf-8");
-    } catch {
-        return null;
-    }
-}
+  const urlSource = baseUrl ? UrlSource.Detected : UrlSource.FrameworkDefault;
 
-const extractPortFromDevScript = (packageJson: any): number | null => {
-    const devScript = packageJson?.scripts?.dev ?? packageJson?.scripts?.start;
-    if (typeof devScript !== "string") return null;
+  const urlKeys = APP_TYPE_URL_CONFIGS[quickstartSpec.appType];
 
-    const match = devScript.match(/(?:-p|--port)\s+(\d+)/);
-    return match ? parseInt(match[1], 10) : null;
-}
+  const callbackUrl = quickstartSpec.callbackPath
+    ? `${resolvedBaseUrl}${quickstartSpec.callbackPath}`
+    : resolvedBaseUrl;
 
-async function detectPortFromViteConfig(projectPath: string): Promise<number | null> {
-    for (const filename of ['vite.config.ts', 'vite.config.js', 'vite.config.mts', 'vite.config.mjs']) {
-      const content = await readTextFile(join(projectPath, filename));
-      if (!content) continue;
+  const logoutUrl = quickstartSpec.logoutPath
+    ? `${resolvedBaseUrl}${quickstartSpec.logoutPath}`
+    : resolvedBaseUrl;
 
-      const match = content.match(/server\s*:\s*\{[^}]*port\s*:\s*(\d+)/s);
-      if (match) return parseInt(match[1], 10);
-    }
-    return null;
-  }
-
-async function detectPortFromAngularJson(projectPath: string): Promise<number | null> {
-    const angularJson = await readJsonFile(join(projectPath, 'angular.json'));
-    if (!angularJson) return null;
-
-    const projects = angularJson.projects ?? {};
-    for (const project of Object.values(projects) as any[]) {
-      const port = project?.architect?.serve?.options?.port;
-      if (typeof port === 'number') return port;
-    }
-    return null;
-  }
-
-  async function detectPortFromProject(projectPath: string): Promise<number | null> {
-    // Try package.json dev script first
-    const packageJson = await readJsonFile(join(projectPath, 'package.json'));
-    if (packageJson) {
-      const port = extractPortFromDevScript(packageJson);
-      if (port) return port;
-    }
-
-    // Try vite config
-    const vitePort = await detectPortFromViteConfig(projectPath);
-    if (vitePort) return vitePort;
-
-    // Try angular.json
-    const angularPort = await detectPortFromAngularJson(projectPath);
-    if (angularPort) return angularPort;
-
-    return null;
-  }
-
-  function replacePort(baseUrl: string, port: number): string {
-    const url = new URL(baseUrl);
-    url.port = String(port);
-    return url.origin;
-  }
-
-export const resolveCallbackUrls = async (
-    projectPath: string | undefined, 
-    quickstartSpec: QuickstartSpec,
-    explicitBaseUrl?: string
-): Promise<ResolvedCallbackUrls> => {
-    let baseUrl: string;
-    let urlSource: UrlSource;
-    // TODO: Add tests for this to ensure white spaces and slashes are removed
-    if (explicitBaseUrl) {
-        baseUrl = explicitBaseUrl.trim().replace(/\/+$/, "");
-        urlSource = UrlSource.Explicit;
-    } else if (projectPath) {
-        const detectedPort = await detectPortFromProject(projectPath);
-
-        if (detectedPort) {
-            baseUrl = replacePort(quickstartSpec.defaultAppOrigin, detectedPort);
-            urlSource = UrlSource.ProjectConfig;
-        } else {
-            baseUrl = quickstartSpec.defaultAppOrigin
-            urlSource = UrlSource.FrameWorkDefault;
-        }
-    } else {
-        baseUrl = quickstartSpec.defaultAppOrigin;
-        urlSource = UrlSource.FrameWorkDefault;
-    }
-
-    const callbackUrl = quickstartSpec.callbackPath
-        ? `${baseUrl}${quickstartSpec.callbackPath}`
-        : baseUrl;
-    
-    const logoutUrl = quickstartSpec.logoutPath
-        ? `${baseUrl}${quickstartSpec.logoutPath}`
-        : baseUrl;
-    
-    return {
-        base_url: baseUrl,
-        callback_urls: [callbackUrl],
-        logout_urls: [logoutUrl],
-        web_origins: [baseUrl],
-        url_source: urlSource,
-    }
-} 
+  return {
+    base_url: resolvedBaseUrl,
+    ...(urlKeys.has('callback_urls') && { callback_urls: [callbackUrl] }),
+    ...(urlKeys.has('logout_urls') && { logout_urls: [logoutUrl] }),
+    ...(urlKeys.has('web_origins') && { web_origins: [resolvedBaseUrl] }),
+    url_source: urlSource,
+  };
+};

--- a/src/utils/onboarding.ts
+++ b/src/utils/onboarding.ts
@@ -1,4 +1,4 @@
-import { QuickstartSpec, QuickstartAppType } from './types';
+import { QuickstartSpec, QuickstartAppType, DefaultAppOrigin } from './types';
 
 export enum UrlSource {
   Detected = 'detected',
@@ -19,10 +19,17 @@ const APP_TYPE_URL_CONFIGS: Record<QuickstartAppType, Set<string>> = {
   native: new Set(['callback_urls', 'logout_urls']),
 };
 
+export const resolveDefaultOrigin = (defaultAppOrigin: DefaultAppOrigin): string => {
+  const { scheme, domain, port } = defaultAppOrigin;
+  const resolvedPort = port !== undefined ? String(port) : '';
+
+  return new URL(`${scheme}://${domain}${resolvedPort ? `:${resolvedPort}` : ''}`).origin;
+};
+
 export const resolveCallbackUrls = (quickstartSpec: QuickstartSpec, baseUrl?: string) => {
   const resolvedBaseUrl = baseUrl
     ? baseUrl.trim().replace(/\/+$/, '')
-    : quickstartSpec.defaultAppOrigin;
+    : resolveDefaultOrigin(quickstartSpec.defaultAppOrigin);
 
   const urlSource = baseUrl ? UrlSource.Detected : UrlSource.FrameworkDefault;
 

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -67,3 +67,12 @@ export interface Auth0PaginatedResponse {
   per_page?: number;
   [key: string]: any;
 }
+
+export type QuickstartAppType = 'spa' | 'webapp' | 'native';
+
+export interface QuickstartSpec {
+  appType: QuickstartAppType;
+  defaultAppOrigin: string;
+  callbackPath: string;
+  logoutPath: string;
+}

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -70,9 +70,14 @@ export interface Auth0PaginatedResponse {
 
 export type QuickstartAppType = 'spa' | 'webapp' | 'native';
 
+export interface DefaultAppOrigin {
+  scheme: string;
+  domain: string;
+  port?: number;
+}
 export interface QuickstartSpec {
   appType: QuickstartAppType;
-  defaultAppOrigin: string;
+  defaultAppOrigin: DefaultAppOrigin;
   callbackPath: string;
   logoutPath: string;
 }

--- a/test/utils/onboarding.test.ts
+++ b/test/utils/onboarding.test.ts
@@ -1,0 +1,380 @@
+import { describe, it, expect, vi, beforeEach} from "vitest";
+import { resolveCallbackUrls, UrlSource } from "../../src/utils/onboarding";
+import type { QuickstartSpec } from "../../src/utils/onboarding";
+
+vi.mock("fs/promises", () => ({
+    readFile: vi.fn(),
+}));
+
+import { readFile } from "fs/promises";
+import { deflate } from "zlib";
+
+const mockReadFile = vi.mocked(readFile);
+
+const defaultSpec: QuickstartSpec = {
+    defaultAppOrigin: "http://localhost:3000",
+    callbackPath: "/callback",
+    logoutPath: "/logout"
+};
+
+describe("resolveCallbackUrls", () => {
+    beforeEach(() => {
+        vi.resetAllMocks();
+    });
+
+    describe("with explicit base url", () => {
+        it("should use the explicit URL as base", async () => {
+            const explicitBaseUrl = "http://localhost:4000";
+            const result = await resolveCallbackUrls(undefined, defaultSpec, explicitBaseUrl);
+
+            expect(result.base_url).toBe(explicitBaseUrl);
+            expect(result.callback_urls).toEqual([`${explicitBaseUrl}/callback`]);
+            expect(result.logout_urls).toEqual([`${explicitBaseUrl}/logout`]);
+            expect(result.web_origins).toEqual([explicitBaseUrl]);
+            expect(result.url_source).toBe(UrlSource.Explicit);
+        });
+
+        it("should strip trailing slashes from explicit URL", async () => {
+            const result = await resolveCallbackUrls(undefined, defaultSpec, "http://localhost:4000////");
+            expect(result.base_url).toBe("http://localhost:4000");
+        });
+
+        it("should trim whitespace from explicit URL", async () => {
+            const result = await resolveCallbackUrls(undefined, defaultSpec, "   http://localhost:4000  ");
+            expect(result.base_url).toBe("http://localhost:4000");
+        });
+
+        it("should trim whitespaces and strip trailing slashes together", async () => {
+            const result = await resolveCallbackUrls(undefined, defaultSpec, "  http://localhost:4000/// ");
+            expect(result.base_url).toBe("http://localhost:4000");
+        });
+
+        it("should take priority over projectPath", async () => {
+            const expectedBaseUrl = "http://explicit:8080";
+            const result = await resolveCallbackUrls("/some/project", defaultSpec, expectedBaseUrl);
+
+            expect(result.base_url).toBe(expectedBaseUrl);
+            expect(result.url_source).toBe(UrlSource.Explicit);
+        });
+    });
+
+    describe("projectPath with no explicitBaseUrl", () => {
+        describe("detect port from package.json", () => {
+            it("should detect --port flag in dev script", async () => {
+                mockReadFile.mockImplementation(async (filePath: any) => {
+                    if (filePath.endsWith("package.json")) {
+                        return JSON.stringify({ scripts: { dev: "vite --port 5173" } });
+                    }
+                    throw new Error("ENOENT");
+                });
+
+                const result = await resolveCallbackUrls("/project", defaultSpec);
+                expect(result.base_url).toBe("http://localhost:5173");
+                expect(result.url_source).toBe(UrlSource.ProjectConfig);
+            });
+
+            it("should detect -p flag in dev script", async () => {
+                mockReadFile.mockImplementation(async (filePath:any) => {
+                    if (filePath.endsWith("package.json")) {
+                        return JSON.stringify({ scripts: { dev: "next dev -p 4000" } });
+                    }
+                    throw new Error("ENOENT");
+                });
+
+                const result = await resolveCallbackUrls("/project", defaultSpec);
+
+                expect(result.base_url).toBe("http://localhost:4000");
+                expect(result.url_source).toBe(UrlSource.ProjectConfig);
+            });
+
+            it("should fall back to start script if no dev script", async () => {
+                mockReadFile.mockImplementation(async (filePath: any) => {
+                    if (filePath.endsWith("package.json")) {
+                        return JSON.stringify({ scripts: { start: "react-scripts start --port 3001" } });
+                    }
+                    throw new Error("ENOENT");
+                });
+
+                const result = await resolveCallbackUrls("/project", defaultSpec);
+
+                expect(result.base_url).toBe("http://localhost:3001");
+                expect(result.url_source).toBe(UrlSource.ProjectConfig);
+            });
+
+            it("should not detect port if not --port or -p flag", async () => {
+                mockReadFile.mockImplementation(async (filePath: any) => {
+                    if (filePath.endsWith("package.json")) {
+                        return JSON.stringify({ scripts: { dev: 'vite' } });
+                    }
+                    throw new Error("ENOENT");
+                });
+
+                const result = await resolveCallbackUrls("/project", defaultSpec);
+
+                expect(result.base_url).toBe("http://localhost:3000");
+                expect(result.url_source).toBe(UrlSource.FrameWorkDefault);
+            });
+        });
+
+        describe("port from vite config", () => {
+            it("should detect port from vite.config.ts", async () => {
+                mockReadFile.mockImplementation(async (filePath: any) => {
+                    if (filePath.endsWith("package.json")) {
+                        return JSON.stringify({ scripts: { dev: "vite" } } );
+                    }
+                    if (filePath.endsWith("vite.config.ts")) {
+                        return `export default defineConfig({ server: { port: 8080 } })`;
+                    }
+                    throw new Error('ENOENT');
+                });
+
+                const result = await resolveCallbackUrls("/project", defaultSpec);
+
+                expect(result.base_url).toBe("http://localhost:8080");
+                expect(result.url_source).toBe(UrlSource.ProjectConfig);
+            });
+
+            it("should detect port from vite.config.js", async () => {
+                mockReadFile.mockImplementation(async (filePath: any) => {
+                      if (filePath.endsWith('package.json')) {
+                          return JSON.stringify({ scripts: { dev: 'vite' } });
+                      }
+                      if (filePath.endsWith('vite.config.js')) {
+                          return `module.exports = { server: { port: 9090 } }`;
+                      }
+                      throw new Error('ENOENT');
+                  });
+
+                  const result = await resolveCallbackUrls('/project', defaultSpec);
+
+                  expect(result.base_url).toBe('http://localhost:9090');
+                  expect(result.url_source).toBe(UrlSource.ProjectConfig);
+            });
+
+            it('should detect port from vite.config.mts', async () => {
+                mockReadFile.mockImplementation(async (filePath: any) => {
+                    if (filePath.endsWith('package.json')) {
+                        return JSON.stringify({});
+                    }
+                    if (filePath.endsWith('vite.config.mts')) {
+                        return `export default { server: { port: 7777 } }`;
+                    }
+                    throw new Error('ENOENT');
+                });
+
+                const result = await resolveCallbackUrls('/project', defaultSpec);
+
+                expect(result.base_url).toBe('http://localhost:7777');
+                expect(result.url_source).toBe(UrlSource.ProjectConfig);
+            });
+
+            it("should not detect port if vite config has no server.port", async () => {
+                mockReadFile.mockImplementation(async (filePath: any) => {
+                    if (filePath.endsWith("package.json")) {
+                        return JSON.stringify({});
+                    }
+                    if (filePath.endsWith("vite.config.ts")) {
+                        return `export default defineConfig({ plugins: [react()] })`;
+                    }
+                    throw new Error('ENOENT');
+                });
+
+                const result = await resolveCallbackUrls('/project', defaultSpec);
+
+                expect(result.base_url).toBe('http://localhost:3000');
+                expect(result.url_source).toBe(UrlSource.FrameWorkDefault);
+            });
+        });
+
+        describe("port from angular.json", () => {
+            it("should detect port from angular.json serve options", async () => {
+                mockReadFile.mockImplementation(async (filePath: any) => {
+                    if (filePath.endsWith("package.json")) {
+                        return JSON.stringify({});
+                    }
+                    if (filePath.endsWith("angular.json")) {
+                        return JSON.stringify({
+                            projects: {
+                                myApp: {
+                                    architect: {
+                                        serve: { options: { port: 4200 } },
+                                    }
+                                }
+                            }
+                        })
+                    }
+                    throw new Error("ENOENT");
+                });
+
+                const result = await resolveCallbackUrls("/project", defaultSpec);
+                
+                expect(result.base_url).toBe("http://localhost:4200");
+                expect(result.url_source).toBe(UrlSource.ProjectConfig);
+            });
+
+            it("should return null if angular.json has no port", async () => {
+                mockReadFile.mockImplementation(async (filePath: any) => {
+                    if (filePath.endsWith("package.json")) {
+                        return JSON.stringify({});
+                    }
+                    if (filePath.endsWith("angular.json")) {
+                        return JSON.stringify({
+                            projects: {
+                                myApp: {
+                                    architect: {
+                                        server: { options: {} },
+                                    }
+                                }
+                            }
+                        })
+                    }
+                    throw new Error("ENOENT");
+                });
+
+                const result = await resolveCallbackUrls("/project", defaultSpec);
+
+                expect(result.base_url).toBe("http://localhost:3000");
+                expect(result.url_source).toBe(UrlSource.FrameWorkDefault);
+            });
+        });
+
+        describe("detection priority", () => {
+            it("should prefer package.json port over vite config", async () => {
+                mockReadFile.mockImplementation(async (filePath: any) => {
+                    if (filePath.endsWith('package.json')) {
+                        return JSON.stringify({ scripts: { dev: 'vite --port 1111' } });
+                    }
+                    if (filePath.endsWith('vite.config.ts')) {
+                        return `export default { server: { port: 2222 } }`;
+                    }
+                    throw new Error('ENOENT');
+                });
+
+                const result = await resolveCallbackUrls("/project", defaultSpec);
+
+                expect(result.base_url).toBe("http://localhost:1111");
+            });
+
+            it("should prefer vite config over angular.json", async () => {
+                mockReadFile.mockImplementation(async (filePath: any) => {
+                    if (filePath.endsWith('package.json')) {
+                        return JSON.stringify({});
+                    }
+                    if (filePath.endsWith('vite.config.ts')) {
+                        return `export default { server: { port: 2222 } }`;
+                    }
+                    if (filePath.endsWith('angular.json')) {
+                        return JSON.stringify({
+                            projects: { app: { architect: { serve: { options: { port: 3333 } } } } },
+                        });
+                    }
+                    throw new Error('ENOENT');
+                });
+
+                const result = await resolveCallbackUrls("/project", defaultSpec);
+
+                expect(result.base_url).toBe("http://localhost:2222");
+            });
+
+            it("should fall back to framework default when no port is detected", async () => {
+                mockReadFile.mockImplementation(async () => {
+                    throw new Error('ENOENT');
+                });
+
+                const result = await resolveCallbackUrls("/project", defaultSpec);
+
+                expect(result.base_url).toBe('http://localhost:3000');
+                expect(result.url_source).toBe(UrlSource.FrameWorkDefault);
+            });
+        });
+
+        describe("with no projectPath and no explicitBaseUrl", () => {
+            it("should use framework default origin", async () => {
+                const expectedBaseUrl = "http://localhost:3000";
+                const result = await resolveCallbackUrls(undefined, defaultSpec);
+
+                expect(result.base_url).toBe(expectedBaseUrl);
+                expect(result.callback_urls).toEqual([`${expectedBaseUrl}/callback`]);
+                expect(result.logout_urls).toEqual([`${expectedBaseUrl}/logout`]);
+                expect(result.web_origins).toEqual([expectedBaseUrl]);
+                expect(result.url_source).toBe(UrlSource.FrameWorkDefault);
+            });
+        });
+
+        describe("callback and logout path handling", () => {
+            it("should use base URL when callbackPath is empty", async () => {
+                const spec: QuickstartSpec = {
+                    defaultAppOrigin: "http://localhost:3000",
+                    callbackPath: "",
+                    logoutPath: "/logout"
+                }
+
+                const result = await resolveCallbackUrls(undefined, spec);
+
+                expect(result.callback_urls).toEqual(["http://localhost:3000"]);
+                expect(result.logout_urls).toEqual(["http://localhost:3000/logout"]);
+            });
+
+            it("should use base URL when logoutPath is empty", async () => {
+                const spec: QuickstartSpec = {
+                    defaultAppOrigin: "http://localhost:3000",
+                    callbackPath: "/callback",
+                    logoutPath: "",
+                };
+
+                const result = await resolveCallbackUrls(undefined, spec);
+
+                expect(result.callback_urls).toEqual(["http://localhost:3000/callback"]);
+                expect(result.logout_urls).toEqual(["http://localhost:3000"]);
+            });
+
+            it("should use base URL for both when callbackPath and logoutPath are empty", async () => {
+                const baseUrl = "http://localhost:3000";
+                
+                const spec: QuickstartSpec = {
+                    defaultAppOrigin: baseUrl,
+                    callbackPath: "",
+                    logoutPath: "",
+                };
+
+                const result = await resolveCallbackUrls(undefined, spec);
+
+                expect(result.callback_urls).toEqual([baseUrl]);
+                expect(result.logout_urls).toEqual([baseUrl]);
+            });
+        });
+
+        describe("file read error handling", () => {
+            it("should handle malformed JSON in package.json gracefully", async () => {
+                mockReadFile.mockImplementation(async (filePath: any) => {
+                    if (filePath.endsWith("package.json")) {
+                        return "{ invalid json }";
+                    }
+                    throw new Error("ENOENT");
+                });
+
+                const result = await resolveCallbackUrls("/project", defaultSpec);
+
+                expect(result.base_url).toBe("http://localhost:3000");
+                expect(result.url_source).toBe(UrlSource.FrameWorkDefault);
+            });
+
+            it("should handle malformed JSON in angular.json gracefully", async () => {
+                mockReadFile.mockImplementation(async (filePath: any) => {
+                    if (filePath.endsWith("pacakage.json")) {
+                        return JSON.stringify({});
+                    }
+                    if (filePath.endsWith("angular.json")) {
+                        return "{ not valid }";
+                    }
+                    throw new Error("ENOENT");
+                });
+
+                const result = await resolveCallbackUrls("/project", defaultSpec);
+
+                expect(result.base_url).toBe("http://localhost:3000");
+                expect(result.url_source).toBe(UrlSource.FrameWorkDefault);
+            });
+        });
+    });
+});

--- a/test/utils/onboarding.test.ts
+++ b/test/utils/onboarding.test.ts
@@ -1,380 +1,117 @@
-import { describe, it, expect, vi, beforeEach} from "vitest";
-import { resolveCallbackUrls, UrlSource } from "../../src/utils/onboarding";
-import type { QuickstartSpec } from "../../src/utils/onboarding";
-
-vi.mock("fs/promises", () => ({
-    readFile: vi.fn(),
-}));
-
-import { readFile } from "fs/promises";
-import { deflate } from "zlib";
-
-const mockReadFile = vi.mocked(readFile);
+import { describe, it, expect } from 'vitest';
+import { resolveCallbackUrls, UrlSource } from '../../src/utils/onboarding';
+import type { QuickstartSpec } from '../../src/utils/types';
 
 const defaultSpec: QuickstartSpec = {
-    defaultAppOrigin: "http://localhost:3000",
-    callbackPath: "/callback",
-    logoutPath: "/logout"
+  appType: 'spa',
+  defaultAppOrigin: 'http://localhost:3000',
+  callbackPath: '/callback',
+  logoutPath: '/logout',
 };
 
-describe("resolveCallbackUrls", () => {
-    beforeEach(() => {
-        vi.resetAllMocks();
+describe('resolveCallbackUrls', () => {
+  describe('with base URL provided', () => {
+    it('should use the provided base url', () => {
+      const expectedBaseUrl = 'http://localhost:4000';
+      const result = resolveCallbackUrls(defaultSpec, expectedBaseUrl);
+
+      expect(result.base_url).toBe(expectedBaseUrl);
+      expect(result.callback_urls).toEqual([`${expectedBaseUrl}/callback`]);
+      expect(result.logout_urls).toEqual([`${expectedBaseUrl}/logout`]);
+      expect(result.web_origins).toEqual([expectedBaseUrl]);
+      expect(result.url_source).toBe(UrlSource.Detected);
     });
 
-    describe("with explicit base url", () => {
-        it("should use the explicit URL as base", async () => {
-            const explicitBaseUrl = "http://localhost:4000";
-            const result = await resolveCallbackUrls(undefined, defaultSpec, explicitBaseUrl);
-
-            expect(result.base_url).toBe(explicitBaseUrl);
-            expect(result.callback_urls).toEqual([`${explicitBaseUrl}/callback`]);
-            expect(result.logout_urls).toEqual([`${explicitBaseUrl}/logout`]);
-            expect(result.web_origins).toEqual([explicitBaseUrl]);
-            expect(result.url_source).toBe(UrlSource.Explicit);
-        });
-
-        it("should strip trailing slashes from explicit URL", async () => {
-            const result = await resolveCallbackUrls(undefined, defaultSpec, "http://localhost:4000////");
-            expect(result.base_url).toBe("http://localhost:4000");
-        });
-
-        it("should trim whitespace from explicit URL", async () => {
-            const result = await resolveCallbackUrls(undefined, defaultSpec, "   http://localhost:4000  ");
-            expect(result.base_url).toBe("http://localhost:4000");
-        });
-
-        it("should trim whitespaces and strip trailing slashes together", async () => {
-            const result = await resolveCallbackUrls(undefined, defaultSpec, "  http://localhost:4000/// ");
-            expect(result.base_url).toBe("http://localhost:4000");
-        });
-
-        it("should take priority over projectPath", async () => {
-            const expectedBaseUrl = "http://explicit:8080";
-            const result = await resolveCallbackUrls("/some/project", defaultSpec, expectedBaseUrl);
-
-            expect(result.base_url).toBe(expectedBaseUrl);
-            expect(result.url_source).toBe(UrlSource.Explicit);
-        });
+    it('should strip trailing slashes from base URL', () => {
+      const result = resolveCallbackUrls(defaultSpec, 'http://localhost:4000/////');
+      expect(result.base_url).toBe('http://localhost:4000');
     });
 
-    describe("projectPath with no explicitBaseUrl", () => {
-        describe("detect port from package.json", () => {
-            it("should detect --port flag in dev script", async () => {
-                mockReadFile.mockImplementation(async (filePath: any) => {
-                    if (filePath.endsWith("package.json")) {
-                        return JSON.stringify({ scripts: { dev: "vite --port 5173" } });
-                    }
-                    throw new Error("ENOENT");
-                });
-
-                const result = await resolveCallbackUrls("/project", defaultSpec);
-                expect(result.base_url).toBe("http://localhost:5173");
-                expect(result.url_source).toBe(UrlSource.ProjectConfig);
-            });
-
-            it("should detect -p flag in dev script", async () => {
-                mockReadFile.mockImplementation(async (filePath:any) => {
-                    if (filePath.endsWith("package.json")) {
-                        return JSON.stringify({ scripts: { dev: "next dev -p 4000" } });
-                    }
-                    throw new Error("ENOENT");
-                });
-
-                const result = await resolveCallbackUrls("/project", defaultSpec);
-
-                expect(result.base_url).toBe("http://localhost:4000");
-                expect(result.url_source).toBe(UrlSource.ProjectConfig);
-            });
-
-            it("should fall back to start script if no dev script", async () => {
-                mockReadFile.mockImplementation(async (filePath: any) => {
-                    if (filePath.endsWith("package.json")) {
-                        return JSON.stringify({ scripts: { start: "react-scripts start --port 3001" } });
-                    }
-                    throw new Error("ENOENT");
-                });
-
-                const result = await resolveCallbackUrls("/project", defaultSpec);
-
-                expect(result.base_url).toBe("http://localhost:3001");
-                expect(result.url_source).toBe(UrlSource.ProjectConfig);
-            });
-
-            it("should not detect port if not --port or -p flag", async () => {
-                mockReadFile.mockImplementation(async (filePath: any) => {
-                    if (filePath.endsWith("package.json")) {
-                        return JSON.stringify({ scripts: { dev: 'vite' } });
-                    }
-                    throw new Error("ENOENT");
-                });
-
-                const result = await resolveCallbackUrls("/project", defaultSpec);
-
-                expect(result.base_url).toBe("http://localhost:3000");
-                expect(result.url_source).toBe(UrlSource.FrameWorkDefault);
-            });
-        });
-
-        describe("port from vite config", () => {
-            it("should detect port from vite.config.ts", async () => {
-                mockReadFile.mockImplementation(async (filePath: any) => {
-                    if (filePath.endsWith("package.json")) {
-                        return JSON.stringify({ scripts: { dev: "vite" } } );
-                    }
-                    if (filePath.endsWith("vite.config.ts")) {
-                        return `export default defineConfig({ server: { port: 8080 } })`;
-                    }
-                    throw new Error('ENOENT');
-                });
-
-                const result = await resolveCallbackUrls("/project", defaultSpec);
-
-                expect(result.base_url).toBe("http://localhost:8080");
-                expect(result.url_source).toBe(UrlSource.ProjectConfig);
-            });
-
-            it("should detect port from vite.config.js", async () => {
-                mockReadFile.mockImplementation(async (filePath: any) => {
-                      if (filePath.endsWith('package.json')) {
-                          return JSON.stringify({ scripts: { dev: 'vite' } });
-                      }
-                      if (filePath.endsWith('vite.config.js')) {
-                          return `module.exports = { server: { port: 9090 } }`;
-                      }
-                      throw new Error('ENOENT');
-                  });
-
-                  const result = await resolveCallbackUrls('/project', defaultSpec);
-
-                  expect(result.base_url).toBe('http://localhost:9090');
-                  expect(result.url_source).toBe(UrlSource.ProjectConfig);
-            });
-
-            it('should detect port from vite.config.mts', async () => {
-                mockReadFile.mockImplementation(async (filePath: any) => {
-                    if (filePath.endsWith('package.json')) {
-                        return JSON.stringify({});
-                    }
-                    if (filePath.endsWith('vite.config.mts')) {
-                        return `export default { server: { port: 7777 } }`;
-                    }
-                    throw new Error('ENOENT');
-                });
-
-                const result = await resolveCallbackUrls('/project', defaultSpec);
-
-                expect(result.base_url).toBe('http://localhost:7777');
-                expect(result.url_source).toBe(UrlSource.ProjectConfig);
-            });
-
-            it("should not detect port if vite config has no server.port", async () => {
-                mockReadFile.mockImplementation(async (filePath: any) => {
-                    if (filePath.endsWith("package.json")) {
-                        return JSON.stringify({});
-                    }
-                    if (filePath.endsWith("vite.config.ts")) {
-                        return `export default defineConfig({ plugins: [react()] })`;
-                    }
-                    throw new Error('ENOENT');
-                });
-
-                const result = await resolveCallbackUrls('/project', defaultSpec);
-
-                expect(result.base_url).toBe('http://localhost:3000');
-                expect(result.url_source).toBe(UrlSource.FrameWorkDefault);
-            });
-        });
-
-        describe("port from angular.json", () => {
-            it("should detect port from angular.json serve options", async () => {
-                mockReadFile.mockImplementation(async (filePath: any) => {
-                    if (filePath.endsWith("package.json")) {
-                        return JSON.stringify({});
-                    }
-                    if (filePath.endsWith("angular.json")) {
-                        return JSON.stringify({
-                            projects: {
-                                myApp: {
-                                    architect: {
-                                        serve: { options: { port: 4200 } },
-                                    }
-                                }
-                            }
-                        })
-                    }
-                    throw new Error("ENOENT");
-                });
-
-                const result = await resolveCallbackUrls("/project", defaultSpec);
-                
-                expect(result.base_url).toBe("http://localhost:4200");
-                expect(result.url_source).toBe(UrlSource.ProjectConfig);
-            });
-
-            it("should return null if angular.json has no port", async () => {
-                mockReadFile.mockImplementation(async (filePath: any) => {
-                    if (filePath.endsWith("package.json")) {
-                        return JSON.stringify({});
-                    }
-                    if (filePath.endsWith("angular.json")) {
-                        return JSON.stringify({
-                            projects: {
-                                myApp: {
-                                    architect: {
-                                        server: { options: {} },
-                                    }
-                                }
-                            }
-                        })
-                    }
-                    throw new Error("ENOENT");
-                });
-
-                const result = await resolveCallbackUrls("/project", defaultSpec);
-
-                expect(result.base_url).toBe("http://localhost:3000");
-                expect(result.url_source).toBe(UrlSource.FrameWorkDefault);
-            });
-        });
-
-        describe("detection priority", () => {
-            it("should prefer package.json port over vite config", async () => {
-                mockReadFile.mockImplementation(async (filePath: any) => {
-                    if (filePath.endsWith('package.json')) {
-                        return JSON.stringify({ scripts: { dev: 'vite --port 1111' } });
-                    }
-                    if (filePath.endsWith('vite.config.ts')) {
-                        return `export default { server: { port: 2222 } }`;
-                    }
-                    throw new Error('ENOENT');
-                });
-
-                const result = await resolveCallbackUrls("/project", defaultSpec);
-
-                expect(result.base_url).toBe("http://localhost:1111");
-            });
-
-            it("should prefer vite config over angular.json", async () => {
-                mockReadFile.mockImplementation(async (filePath: any) => {
-                    if (filePath.endsWith('package.json')) {
-                        return JSON.stringify({});
-                    }
-                    if (filePath.endsWith('vite.config.ts')) {
-                        return `export default { server: { port: 2222 } }`;
-                    }
-                    if (filePath.endsWith('angular.json')) {
-                        return JSON.stringify({
-                            projects: { app: { architect: { serve: { options: { port: 3333 } } } } },
-                        });
-                    }
-                    throw new Error('ENOENT');
-                });
-
-                const result = await resolveCallbackUrls("/project", defaultSpec);
-
-                expect(result.base_url).toBe("http://localhost:2222");
-            });
-
-            it("should fall back to framework default when no port is detected", async () => {
-                mockReadFile.mockImplementation(async () => {
-                    throw new Error('ENOENT');
-                });
-
-                const result = await resolveCallbackUrls("/project", defaultSpec);
-
-                expect(result.base_url).toBe('http://localhost:3000');
-                expect(result.url_source).toBe(UrlSource.FrameWorkDefault);
-            });
-        });
-
-        describe("with no projectPath and no explicitBaseUrl", () => {
-            it("should use framework default origin", async () => {
-                const expectedBaseUrl = "http://localhost:3000";
-                const result = await resolveCallbackUrls(undefined, defaultSpec);
-
-                expect(result.base_url).toBe(expectedBaseUrl);
-                expect(result.callback_urls).toEqual([`${expectedBaseUrl}/callback`]);
-                expect(result.logout_urls).toEqual([`${expectedBaseUrl}/logout`]);
-                expect(result.web_origins).toEqual([expectedBaseUrl]);
-                expect(result.url_source).toBe(UrlSource.FrameWorkDefault);
-            });
-        });
-
-        describe("callback and logout path handling", () => {
-            it("should use base URL when callbackPath is empty", async () => {
-                const spec: QuickstartSpec = {
-                    defaultAppOrigin: "http://localhost:3000",
-                    callbackPath: "",
-                    logoutPath: "/logout"
-                }
-
-                const result = await resolveCallbackUrls(undefined, spec);
-
-                expect(result.callback_urls).toEqual(["http://localhost:3000"]);
-                expect(result.logout_urls).toEqual(["http://localhost:3000/logout"]);
-            });
-
-            it("should use base URL when logoutPath is empty", async () => {
-                const spec: QuickstartSpec = {
-                    defaultAppOrigin: "http://localhost:3000",
-                    callbackPath: "/callback",
-                    logoutPath: "",
-                };
-
-                const result = await resolveCallbackUrls(undefined, spec);
-
-                expect(result.callback_urls).toEqual(["http://localhost:3000/callback"]);
-                expect(result.logout_urls).toEqual(["http://localhost:3000"]);
-            });
-
-            it("should use base URL for both when callbackPath and logoutPath are empty", async () => {
-                const baseUrl = "http://localhost:3000";
-                
-                const spec: QuickstartSpec = {
-                    defaultAppOrigin: baseUrl,
-                    callbackPath: "",
-                    logoutPath: "",
-                };
-
-                const result = await resolveCallbackUrls(undefined, spec);
-
-                expect(result.callback_urls).toEqual([baseUrl]);
-                expect(result.logout_urls).toEqual([baseUrl]);
-            });
-        });
-
-        describe("file read error handling", () => {
-            it("should handle malformed JSON in package.json gracefully", async () => {
-                mockReadFile.mockImplementation(async (filePath: any) => {
-                    if (filePath.endsWith("package.json")) {
-                        return "{ invalid json }";
-                    }
-                    throw new Error("ENOENT");
-                });
-
-                const result = await resolveCallbackUrls("/project", defaultSpec);
-
-                expect(result.base_url).toBe("http://localhost:3000");
-                expect(result.url_source).toBe(UrlSource.FrameWorkDefault);
-            });
-
-            it("should handle malformed JSON in angular.json gracefully", async () => {
-                mockReadFile.mockImplementation(async (filePath: any) => {
-                    if (filePath.endsWith("pacakage.json")) {
-                        return JSON.stringify({});
-                    }
-                    if (filePath.endsWith("angular.json")) {
-                        return "{ not valid }";
-                    }
-                    throw new Error("ENOENT");
-                });
-
-                const result = await resolveCallbackUrls("/project", defaultSpec);
-
-                expect(result.base_url).toBe("http://localhost:3000");
-                expect(result.url_source).toBe(UrlSource.FrameWorkDefault);
-            });
-        });
+    it('should trim whitespace from base URL', () => {
+      const result = resolveCallbackUrls(defaultSpec, '   http://localhost:4000 ');
+      expect(result.base_url).toBe('http://localhost:4000');
     });
+
+    it('should trim whitespace and strip trailing slashes together', () => {
+      const result = resolveCallbackUrls(defaultSpec, ' http://localhost:4000////  ');
+      expect(result.base_url).toBe('http://localhost:4000');
+    });
+  });
+
+  describe('with no base URL', () => {
+    it('should use framework default origin', () => {
+      const result = resolveCallbackUrls(defaultSpec);
+
+      expect(result.base_url).toBe('http://localhost:3000');
+      expect(result.callback_urls).toEqual(['http://localhost:3000/callback']);
+      expect(result.logout_urls).toEqual(['http://localhost:3000/logout']);
+      expect(result.web_origins).toEqual(['http://localhost:3000']);
+      expect(result.url_source).toBe(UrlSource.FrameworkDefault);
+    });
+  });
+
+  describe('callback and logout path handling', () => {
+    it('should use base URL when callbackPath is empty', () => {
+      const spec: QuickstartSpec = { ...defaultSpec, callbackPath: '' };
+      const result = resolveCallbackUrls(spec);
+
+      expect(result.callback_urls).toEqual(['http://localhost:3000']);
+      expect(result.logout_urls).toEqual(['http://localhost:3000/logout']);
+    });
+
+    it('should use base URL when logoutPath is empty', () => {
+      const spec: QuickstartSpec = { ...defaultSpec, logoutPath: '' };
+      const result = resolveCallbackUrls(spec);
+
+      expect(result.callback_urls).toEqual(['http://localhost:3000/callback']);
+      expect(result.logout_urls).toEqual(['http://localhost:3000']);
+    });
+
+    it('should use base URL for both when paths are empty', () => {
+      const spec: QuickstartSpec = { ...defaultSpec, callbackPath: '', logoutPath: '' };
+      const result = resolveCallbackUrls(spec);
+
+      expect(result.callback_urls).toEqual(['http://localhost:3000']);
+      expect(result.logout_urls).toEqual(['http://localhost:3000']);
+    });
+  });
+
+  describe('app type URL filtering', () => {
+    it('should include all URL types for spa', () => {
+      const result = resolveCallbackUrls({ ...defaultSpec, appType: 'spa' });
+
+      expect(result.callback_urls).toEqual(['http://localhost:3000/callback']);
+      expect(result.logout_urls).toEqual(['http://localhost:3000/logout']);
+      expect(result.web_origins).toEqual(['http://localhost:3000']);
+    });
+
+    it('should omit web_origins for webapp', () => {
+      const result = resolveCallbackUrls({ ...defaultSpec, appType: 'webapp' });
+
+      expect(result.callback_urls).toEqual(['http://localhost:3000/callback']);
+      expect(result.logout_urls).toEqual(['http://localhost:3000/logout']);
+      expect(result.web_origins).toBeUndefined();
+    });
+
+    it('should omit web_origins for native', () => {
+      const result = resolveCallbackUrls({ ...defaultSpec, appType: 'native' });
+
+      expect(result.callback_urls).toEqual(['http://localhost:3000/callback']);
+      expect(result.logout_urls).toEqual(['http://localhost:3000/logout']);
+      expect(result.web_origins).toBeUndefined();
+    });
+
+    it('should apply app type filtering with provided base URL', () => {
+      const result = resolveCallbackUrls(
+        { ...defaultSpec, appType: 'webapp' },
+        'http://localhost:8080'
+      );
+
+      expect(result.base_url).toBe('http://localhost:8080');
+      expect(result.callback_urls).toEqual(['http://localhost:8080/callback']);
+      expect(result.logout_urls).toEqual(['http://localhost:8080/logout']);
+      expect(result.web_origins).toBeUndefined();
+      expect(result.url_source).toBe(UrlSource.Detected);
+    });
+  });
 });

--- a/test/utils/onboarding.test.ts
+++ b/test/utils/onboarding.test.ts
@@ -1,13 +1,44 @@
 import { describe, it, expect } from 'vitest';
-import { resolveCallbackUrls, UrlSource } from '../../src/utils/onboarding';
-import type { QuickstartSpec } from '../../src/utils/types';
+import { resolveCallbackUrls, resolveDefaultOrigin, UrlSource } from '../../src/utils/onboarding';
+import type { QuickstartSpec, DefaultAppOrigin } from '../../src/utils/types';
 
 const defaultSpec: QuickstartSpec = {
   appType: 'spa',
-  defaultAppOrigin: 'http://localhost:3000',
+  defaultAppOrigin: {
+    scheme: 'http',
+    domain: 'localhost',
+    port: 3000,
+  },
   callbackPath: '/callback',
   logoutPath: '/logout',
 };
+
+describe('resolveDefaultOrigin', () => {
+  it('should resolve domain with port', () => {
+    const origin: DefaultAppOrigin = { scheme: 'http', domain: 'localhost', port: 3000 };
+    expect(resolveDefaultOrigin(origin)).toBe('http://localhost:3000');
+  });
+
+  it('should resolve without port when port is undefined', () => {
+    const origin: DefaultAppOrigin = { scheme: 'https', domain: 'example.com' };
+    expect(resolveDefaultOrigin(origin)).toBe('https://example.com');
+  });
+
+  it('should normalize default port 80 for http', () => {
+    const origin: DefaultAppOrigin = { scheme: 'http', domain: 'localhost', port: 80 };
+    expect(resolveDefaultOrigin(origin)).toBe('http://localhost');
+  });
+
+  it('should normalize default port 443 for https', () => {
+    const origin: DefaultAppOrigin = { scheme: 'https', domain: 'example.com', port: 443 };
+    expect(resolveDefaultOrigin(origin)).toBe('https://example.com');
+  });
+
+  it('should handle non-default ports', () => {
+    const origin: DefaultAppOrigin = { scheme: 'https', domain: 'example.com', port: 8443 };
+    expect(resolveDefaultOrigin(origin)).toBe('https://example.com:8443');
+  });
+});
 
 describe('resolveCallbackUrls', () => {
   describe('with base URL provided', () => {
@@ -39,7 +70,7 @@ describe('resolveCallbackUrls', () => {
   });
 
   describe('with no base URL', () => {
-    it('should use framework default origin', () => {
+    it('should resolve from defaultAppOrigin object', () => {
       const result = resolveCallbackUrls(defaultSpec);
 
       expect(result.base_url).toBe('http://localhost:3000');
@@ -47,6 +78,18 @@ describe('resolveCallbackUrls', () => {
       expect(result.logout_urls).toEqual(['http://localhost:3000/logout']);
       expect(result.web_origins).toEqual(['http://localhost:3000']);
       expect(result.url_source).toBe(UrlSource.FrameworkDefault);
+    });
+
+    it('should handle defaultAppOrigin without port', () => {
+      const spec: QuickstartSpec = {
+        ...defaultSpec,
+        defaultAppOrigin: { scheme: 'https', domain: 'example.com' },
+      };
+
+      const result = resolveCallbackUrls(spec);
+
+      expect(result.base_url).toBe('https://example.com');
+      expect(result.callback_urls).toEqual(['https://example.com/callback']);
     });
   });
 


### PR DESCRIPTION
### Changes

This PR introduces a utility function that determines the appropriate base url, callback, logout, and web origin for a specific frameworks based on a quickstart specification (fetching quickstart specs will be added in a future PR to this repo). This utility function takes the following parameters:

- projectPath: string (users local path to their project)
- quickstartSpec: object (a spec based on a framework's SDK quickstart, a fetch for this spec will be added in a future PR)
- explicitBaseUrl: string (a user provided base url, not inferred by the LLM)

The following changes have been implemented
- Added an `onboarding.ts` file under `src/utils`.
- Created a `resolveCallbackUrls` utility function to resolve the correct URLs that are set during quickstart implementation.  
- Added other utility functions to support `resolveCallbackUrls`.
- Added an `onboarding.test.ts` file with appropriate unit tests.

### References

Please include relevant links supporting this change such as a:

[https://auth0team.atlassian.net/browse/DXAA-554](https://auth0team.atlassian.net/browse/DXAA-554)

### Testing

The `resolveCallbackUrl` function is not called by any other functions until we implement the future quickstart tool. In the meantime, to test functionality, a suite of unit tests was added. 

Unit tests have been added to verify:
- White space and trailing slashes removed from explicit base url branch
- Port detection works when passed in the dev and start scripts
- Detection priority tested: package.json > vite > angular
- Path handling for empty callbackPath and logoutPath (both from quickstart spec) 
- Error handling for malformed json
- Fallback to frame work default if no explicit base url or project path passed as variables

- [x] This change adds unit test coverage
- [ ] This change adds integration test coverage

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
