### PR TITLE
[DXAA-525] feat: auto-set token_endpoint_auth_method for created applications

### DIFF
--- a/src/tools/applications.ts
+++ b/src/tools/applications.ts
@@ -134,6 +134,12 @@ export const APPLICATION_TOOLS: Tool[] = [
           enum: ['no_prompt', 'pre_login_prompt', 'post_login_prompt'],
           description: 'How to proceed during authentication when organization_usage is require.',
         },
+        token_endpoint_auth_method: {
+          type: 'string',
+          description:
+            'Token endpoint authentication method. Defaults based on app_type: "none" for SPA/Native (public clients), "client_secret_post" for Regular Web/M2M (confidential clients).',
+          enum: ['none', 'client_secret_post', 'client_secret_basic'],
+        },
       },
       required: ['name'],
     },
@@ -581,9 +587,15 @@ export const APPLICATION_HANDLERS: Record<
       if (allowed_clients !== undefined) clientData.allowed_clients = allowed_clients;
       if (allowed_logout_urls !== undefined) clientData.allowed_logout_urls = allowed_logout_urls;
       if (grant_types !== undefined) clientData.grant_types = grant_types;
-      if (token_endpoint_auth_method !== undefined)
+      if (token_endpoint_auth_method !== undefined) {
         clientData.token_endpoint_auth_method =
           token_endpoint_auth_method as ClientCreateTokenEndpointAuthMethodEnum;
+      } else if (app_type !== undefined) {
+        const isPublicClient = app_type === 'spa' || app_type === 'native';
+        clientData.token_endpoint_auth_method = (
+          isPublicClient ? 'none' : 'client_secret_post'
+        ) as ClientCreateTokenEndpointAuthMethodEnum;
+      }
       if (is_first_party !== undefined) clientData.is_first_party = is_first_party;
       if (oidc_conformant !== undefined) clientData.oidc_conformant = oidc_conformant;
       if (jwt_configuration !== undefined) clientData.jwt_configuration = jwt_configuration;

--- a/src/tools/applications.ts
+++ b/src/tools/applications.ts
@@ -137,7 +137,7 @@ export const APPLICATION_TOOLS: Tool[] = [
         token_endpoint_auth_method: {
           type: 'string',
           description:
-            'Token endpoint authentication method. Defaults based on app_type: "none" for SPA/Native (public clients), "client_secret_post" for Regular Web/M2M (confidential clients).',
+            'Token endpoint authentication method. When creating, defaults based on app_type: "none" for SPA/Native (public clients), "client_secret_post" for Regular Web/M2M (confidential clients).',
           enum: ['none', 'client_secret_post', 'client_secret_basic'],
         },
       },
@@ -587,15 +587,15 @@ export const APPLICATION_HANDLERS: Record<
       if (allowed_clients !== undefined) clientData.allowed_clients = allowed_clients;
       if (allowed_logout_urls !== undefined) clientData.allowed_logout_urls = allowed_logout_urls;
       if (grant_types !== undefined) clientData.grant_types = grant_types;
-      if (token_endpoint_auth_method !== undefined) {
-        clientData.token_endpoint_auth_method =
-          token_endpoint_auth_method as ClientCreateTokenEndpointAuthMethodEnum;
-      } else if (app_type !== undefined) {
-        const isPublicClient = app_type === 'spa' || app_type === 'native';
-        clientData.token_endpoint_auth_method = (
-          isPublicClient ? 'none' : 'client_secret_post'
-        ) as ClientCreateTokenEndpointAuthMethodEnum;
-      }
+      const defaultAuthMethod =
+        app_type === 'spa' || app_type === 'native'
+          ? 'none'
+          : app_type !== undefined
+            ? 'client_secret_post'
+            : undefined;
+      const resolvedAuthMethod = token_endpoint_auth_method ?? defaultAuthMethod;
+      if (resolvedAuthMethod !== undefined)
+        clientData.token_endpoint_auth_method = resolvedAuthMethod as ClientCreateTokenEndpointAuthMethodEnum;
       if (is_first_party !== undefined) clientData.is_first_party = is_first_party;
       if (oidc_conformant !== undefined) clientData.oidc_conformant = oidc_conformant;
       if (jwt_configuration !== undefined) clientData.jwt_configuration = jwt_configuration;

--- a/test/tools/applications.test.ts
+++ b/test/tools/applications.test.ts
@@ -338,6 +338,109 @@ describe('Applications Tool Handlers', () => {
       // Dashboard and API instructions still present
       expect(howToAccess.some((s) => s.includes('Auth0 Dashboard'))).toBe(true);
     });
+
+    it('should default token_endpoint_auth_method to "none" for SPA', async () => {
+      let capturedBody: Record<string, any> = {};
+      server.use(
+        http.post('https://*/api/v2/clients', async ({ request }) => {
+          capturedBody = (await request.json()) as Record<string, any>;
+          return HttpResponse.json({ ...capturedBody, client_id: 'spa-app-id' });
+        })
+      );
+
+      const request = { token, parameters: { name: 'SPA App', app_type: 'spa' } };
+      const response = await APPLICATION_HANDLERS.auth0_create_application(request, { domain });
+
+      expect(response.isError).toBe(false);
+      expect(capturedBody.token_endpoint_auth_method).toBe('none');
+    });
+
+    it('should default token_endpoint_auth_method to "none" for Native', async () => {
+      let capturedBody: Record<string, any> = {};
+      server.use(
+        http.post('https://*/api/v2/clients', async ({ request }) => {
+          capturedBody = (await request.json()) as Record<string, any>;
+          return HttpResponse.json({ ...capturedBody, client_id: 'native-app-id' });
+        })
+      );
+
+      const request = { token, parameters: { name: 'Native App', app_type: 'native' } };
+      const response = await APPLICATION_HANDLERS.auth0_create_application(request, { domain });
+
+      expect(response.isError).toBe(false);
+      expect(capturedBody.token_endpoint_auth_method).toBe('none');
+    });
+
+    it('should default token_endpoint_auth_method to "client_secret_post" for Regular Web', async () => {
+      let capturedBody: Record<string, any> = {};
+      server.use(
+        http.post('https://*/api/v2/clients', async ({ request }) => {
+          capturedBody = (await request.json()) as Record<string, any>;
+          return HttpResponse.json({ ...capturedBody, client_id: 'web-app-id' });
+        })
+      );
+
+      const request = { token, parameters: { name: 'Web App', app_type: 'regular_web' } };
+      const response = await APPLICATION_HANDLERS.auth0_create_application(request, { domain });
+
+      expect(response.isError).toBe(false);
+      expect(capturedBody.token_endpoint_auth_method).toBe('client_secret_post');
+    });
+
+    it('should default token_endpoint_auth_method to "client_secret_post" for M2M', async () => {
+      let capturedBody: Record<string, any> = {};
+      server.use(
+        http.post('https://*/api/v2/clients', async ({ request }) => {
+          capturedBody = (await request.json()) as Record<string, any>;
+          return HttpResponse.json({ ...capturedBody, client_id: 'm2m-app-id' });
+        })
+      );
+
+      const request = { token, parameters: { name: 'M2M App', app_type: 'non_interactive' } };
+      const response = await APPLICATION_HANDLERS.auth0_create_application(request, { domain });
+
+      expect(response.isError).toBe(false);
+      expect(capturedBody.token_endpoint_auth_method).toBe('client_secret_post');
+    });
+
+    it('should use explicit token_endpoint_auth_method over default', async () => {
+      let capturedBody: Record<string, any> = {};
+      server.use(
+        http.post('https://*/api/v2/clients', async ({ request }) => {
+          capturedBody = (await request.json()) as Record<string, any>;
+          return HttpResponse.json({ ...capturedBody, client_id: 'explicit-app-id' });
+        })
+      );
+
+      const request = {
+        token,
+        parameters: {
+          name: 'Explicit Auth App',
+          app_type: 'spa',
+          token_endpoint_auth_method: 'client_secret_basic',
+        },
+      };
+      const response = await APPLICATION_HANDLERS.auth0_create_application(request, { domain });
+
+      expect(response.isError).toBe(false);
+      expect(capturedBody.token_endpoint_auth_method).toBe('client_secret_basic');
+    });
+
+    it('should not set token_endpoint_auth_method when neither app_type nor token_endpoint_auth_method provided', async () => {
+      let capturedBody: Record<string, any> = {};
+      server.use(
+        http.post('https://*/api/v2/clients', async ({ request }) => {
+          capturedBody = (await request.json()) as Record<string, any>;
+          return HttpResponse.json({ ...capturedBody, client_id: 'no-type-app-id' });
+        })
+      );
+
+      const request = { token, parameters: { name: 'No Type App' } };
+      const response = await APPLICATION_HANDLERS.auth0_create_application(request, { domain });
+
+      expect(response.isError).toBe(false);
+      expect(capturedBody.token_endpoint_auth_method).toBeUndefined();
+    });
   });
 
   describe('auth0_update_application', () => {

--- a/test/tools/applications.test.ts
+++ b/test/tools/applications.test.ts
@@ -339,107 +339,62 @@ describe('Applications Tool Handlers', () => {
       expect(howToAccess.some((s) => s.includes('Auth0 Dashboard'))).toBe(true);
     });
 
-    it('should default token_endpoint_auth_method to "none" for SPA', async () => {
-      let capturedBody: Record<string, any> = {};
-      server.use(
-        http.post('https://*/api/v2/clients', async ({ request }) => {
-          capturedBody = (await request.json()) as Record<string, any>;
-          return HttpResponse.json({ ...capturedBody, client_id: 'spa-app-id' });
-        })
+    describe('token_endpoint_auth_method defaults', () => {
+      async function createAppAndCaptureBody(parameters: Record<string, any>) {
+        let capturedBody: Record<string, any> | undefined;
+        server.use(
+          http.post('https://*/api/v2/clients', async ({ request }) => {
+            capturedBody = (await request.json()) as Record<string, any>;
+            return HttpResponse.json({ ...capturedBody, client_id: 'test-app-id' });
+          })
+        );
+
+        const response = await APPLICATION_HANDLERS.auth0_create_application(
+          { token, parameters },
+          { domain }
+        );
+
+        expect(capturedBody).toBeDefined();
+        return { response, capturedBody: capturedBody! };
+      }
+
+      it.each([
+        { app_type: 'spa', expected: 'none' },
+        { app_type: 'native', expected: 'none' },
+        { app_type: 'regular_web', expected: 'client_secret_post' },
+        { app_type: 'non_interactive', expected: 'client_secret_post' },
+      ])(
+        'should default to "$expected" for $app_type',
+        async ({ app_type, expected }) => {
+          const { response, capturedBody } = await createAppAndCaptureBody({
+            name: `${app_type} App`,
+            app_type,
+          });
+
+          expect(response.isError).toBe(false);
+          expect(capturedBody.token_endpoint_auth_method).toBe(expected);
+        }
       );
 
-      const request = { token, parameters: { name: 'SPA App', app_type: 'spa' } };
-      const response = await APPLICATION_HANDLERS.auth0_create_application(request, { domain });
-
-      expect(response.isError).toBe(false);
-      expect(capturedBody.token_endpoint_auth_method).toBe('none');
-    });
-
-    it('should default token_endpoint_auth_method to "none" for Native', async () => {
-      let capturedBody: Record<string, any> = {};
-      server.use(
-        http.post('https://*/api/v2/clients', async ({ request }) => {
-          capturedBody = (await request.json()) as Record<string, any>;
-          return HttpResponse.json({ ...capturedBody, client_id: 'native-app-id' });
-        })
-      );
-
-      const request = { token, parameters: { name: 'Native App', app_type: 'native' } };
-      const response = await APPLICATION_HANDLERS.auth0_create_application(request, { domain });
-
-      expect(response.isError).toBe(false);
-      expect(capturedBody.token_endpoint_auth_method).toBe('none');
-    });
-
-    it('should default token_endpoint_auth_method to "client_secret_post" for Regular Web', async () => {
-      let capturedBody: Record<string, any> = {};
-      server.use(
-        http.post('https://*/api/v2/clients', async ({ request }) => {
-          capturedBody = (await request.json()) as Record<string, any>;
-          return HttpResponse.json({ ...capturedBody, client_id: 'web-app-id' });
-        })
-      );
-
-      const request = { token, parameters: { name: 'Web App', app_type: 'regular_web' } };
-      const response = await APPLICATION_HANDLERS.auth0_create_application(request, { domain });
-
-      expect(response.isError).toBe(false);
-      expect(capturedBody.token_endpoint_auth_method).toBe('client_secret_post');
-    });
-
-    it('should default token_endpoint_auth_method to "client_secret_post" for M2M', async () => {
-      let capturedBody: Record<string, any> = {};
-      server.use(
-        http.post('https://*/api/v2/clients', async ({ request }) => {
-          capturedBody = (await request.json()) as Record<string, any>;
-          return HttpResponse.json({ ...capturedBody, client_id: 'm2m-app-id' });
-        })
-      );
-
-      const request = { token, parameters: { name: 'M2M App', app_type: 'non_interactive' } };
-      const response = await APPLICATION_HANDLERS.auth0_create_application(request, { domain });
-
-      expect(response.isError).toBe(false);
-      expect(capturedBody.token_endpoint_auth_method).toBe('client_secret_post');
-    });
-
-    it('should use explicit token_endpoint_auth_method over default', async () => {
-      let capturedBody: Record<string, any> = {};
-      server.use(
-        http.post('https://*/api/v2/clients', async ({ request }) => {
-          capturedBody = (await request.json()) as Record<string, any>;
-          return HttpResponse.json({ ...capturedBody, client_id: 'explicit-app-id' });
-        })
-      );
-
-      const request = {
-        token,
-        parameters: {
+      it('should use explicit token_endpoint_auth_method over default', async () => {
+        const { response, capturedBody } = await createAppAndCaptureBody({
           name: 'Explicit Auth App',
           app_type: 'spa',
           token_endpoint_auth_method: 'client_secret_basic',
-        },
-      };
-      const response = await APPLICATION_HANDLERS.auth0_create_application(request, { domain });
+        });
 
-      expect(response.isError).toBe(false);
-      expect(capturedBody.token_endpoint_auth_method).toBe('client_secret_basic');
-    });
+        expect(response.isError).toBe(false);
+        expect(capturedBody.token_endpoint_auth_method).toBe('client_secret_basic');
+      });
 
-    it('should not set token_endpoint_auth_method when neither app_type nor token_endpoint_auth_method provided', async () => {
-      let capturedBody: Record<string, any> = {};
-      server.use(
-        http.post('https://*/api/v2/clients', async ({ request }) => {
-          capturedBody = (await request.json()) as Record<string, any>;
-          return HttpResponse.json({ ...capturedBody, client_id: 'no-type-app-id' });
-        })
-      );
+      it('should not set token_endpoint_auth_method when app_type is not provided', async () => {
+        const { response, capturedBody } = await createAppAndCaptureBody({
+          name: 'No Type App',
+        });
 
-      const request = { token, parameters: { name: 'No Type App' } };
-      const response = await APPLICATION_HANDLERS.auth0_create_application(request, { domain });
-
-      expect(response.isError).toBe(false);
-      expect(capturedBody.token_endpoint_auth_method).toBeUndefined();
+        expect(response.isError).toBe(false);
+        expect(capturedBody.token_endpoint_auth_method).toBeUndefined();
+      });
     });
   });
 
@@ -478,6 +433,30 @@ describe('Applications Tool Handlers', () => {
       const appData = parsedContent.data || parsedContent;
       expect(appData.name).toBe('Updated App');
     });
+
+    it.each(['spa', 'native', 'regular_web', 'non_interactive'])(
+      'should not auto-set token_endpoint_auth_method when app_type is %s',
+      async (app_type) => {
+        const clientId = mockApplications[0].client_id;
+        let capturedBody: Record<string, any> | undefined;
+        server.use(
+          http.patch(`https://*/api/v2/clients/${clientId}`, async ({ request }) => {
+            capturedBody = (await request.json()) as Record<string, any>;
+            return HttpResponse.json({ ...mockApplications[0], ...capturedBody });
+          })
+        );
+
+        const request = {
+          token,
+          parameters: { client_id: clientId, app_type },
+        };
+        const response = await APPLICATION_HANDLERS.auth0_update_application(request, { domain });
+
+        expect(response.isError).toBe(false);
+        expect(capturedBody).toBeDefined();
+        expect(capturedBody!.token_endpoint_auth_method).toBeUndefined();
+      }
+    );
   });
 
   describe('auth0_save_credentials_to_file', () => {


### PR DESCRIPTION
### Changes

When `auth0_create_application` is called, it now automatically sets `token_endpoint_auth_method` based on the application type:
- **Public clients** (SPA, Native): defaults to `"none"`
- **Confidential clients** (Regular Web, M2M): defaults to `"client_secret_post"`

This prevents authentication errors for users onboarded via the MCP server, who would otherwise get misconfigured applications.

Specifically:
- Added `token_endpoint_auth_method` to the `auth0_create_application` tool's `inputSchema` so it can be explicitly set
- Added default logic that derives the value from `app_type` when not explicitly provided
- If neither `app_type` nor `token_endpoint_auth_method` is provided, no value is set
- The `auth0_update_application` handler is unchanged — no auto-defaulting on updates

### References

- [DXAA-525](https://auth0team.atlassian.net/browse/DXAA-525)

### Testing
Tested using Claude Code
<img width="660" height="891" alt="Screenshot 2026-04-20 at 4 17 38 PM" src="https://github.com/user-attachments/assets/c45b6dbc-5439-404f-beb2-689fd2b904d9" />


- [x] This change adds unit test coverage
- [ ] This change adds integration test coverage

New tests in `test/tools/applications.test.ts`:
- Parameterized tests for all 4 app types verifying correct default `token_endpoint_auth_method`
- Explicit `token_endpoint_auth_method` overrides the default
- No `token_endpoint_auth_method` set when `app_type` is omitted
- Parameterized tests verifying `auth0_update_application` does NOT auto-set `token_endpoint_auth_method` for any app type

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors