### PR TITLE
[DXAA-603] Set oidc conformant to true and jwt algorithm type to RS256 for auth0_create_application tool

### DIFF
--- a/src/tools/applications.ts
+++ b/src/tools/applications.ts
@@ -652,6 +652,12 @@ export const APPLICATION_HANDLERS: Record<
       if (compliance_level !== undefined)
         clientData.compliance_level = compliance_level as ClientCreateComplianceLevelEnum;
 
+      clientData.oidc_conformant = true;
+      clientData.jwt_configuration = {
+        alg: 'RS256',
+        lifetime_in_seconds: 36000,
+      };
+
       try {
         const managementClientConfig: Auth0Config = {
           domain: config.domain,

--- a/test/tools/applications.test.ts
+++ b/test/tools/applications.test.ts
@@ -393,6 +393,63 @@ describe('Applications Tool Handlers', () => {
         expect(capturedBody.token_endpoint_auth_method).toBeUndefined();
       });
     });
+
+    describe('oidc_conformant and jwt_configuration defaults', () => {
+      async function createAppAndCaptureBody(parameters: Record<string, any>) {
+        let capturedBody: Record<string, any> | undefined;
+        server.use(
+          http.post('https://*/api/v2/clients', async ({ request }) => {
+            capturedBody = (await request.json()) as Record<string, any>;
+            return HttpResponse.json({ ...capturedBody, client_id: 'test-app-id' });
+          })
+        );
+
+        const response = await APPLICATION_HANDLERS.auth0_create_application(
+          { token, parameters },
+          { domain }
+        );
+
+        expect(capturedBody).toBeDefined();
+        return { response, capturedBody: capturedBody! };
+      }
+
+      it('should always set oidc_conformant to true', async () => {
+        const { response, capturedBody } = await createAppAndCaptureBody({
+          name: 'Test App',
+          app_type: 'spa',
+        });
+
+        expect(response.isError).toBe(false);
+        expect(capturedBody.oidc_conformant).toBe(true);
+      });
+
+      it('should always set jwt_configuration with RS256 and lifetime_in_seconds 36000', async () => {
+        const { response, capturedBody } = await createAppAndCaptureBody({
+          name: 'Test App',
+          app_type: 'regular_web',
+        });
+
+        expect(response.isError).toBe(false);
+        expect(capturedBody.jwt_configuration).toBeDefined();
+        expect(capturedBody.jwt_configuration.alg).toBe('RS256');
+        expect(capturedBody.jwt_configuration.lifetime_in_seconds).toBe(36000);
+      });
+
+      it('should set oidc_conformant and jwt_configuration regardless of app_type', async () => {
+        for (const app_type of ['spa', 'native', 'regular_web', 'non_interactive']) {
+          const { capturedBody } = await createAppAndCaptureBody({
+            name: `${app_type} App`,
+            app_type,
+          });
+
+          expect(capturedBody.oidc_conformant).toBe(true);
+          expect(capturedBody.jwt_configuration).toMatchObject({
+            alg: 'RS256',
+            lifetime_in_seconds: 36000,
+          });
+        }
+      });
+    });
   });
 
   describe('auth0_update_application', () => {


### PR DESCRIPTION
### Changes

This PR introduces a change to set `oidc_conformant = true` and the `jwt_configuration` to use the `RS256` algorithm with 
a lifetime of 36000 seconds, for the `auth0_create_application` tool. If these two values are not set, a user that signs up/logs in to their application for the first time using an Auth0 application created with the Auth0 MCP Server will get a vague `Unauthorized` error. 

The following changes have been implemented:

1. Added the following lines of code to the `auth0_create_applications` tool handler found in `src/tools/applications.ts`:

````
clientData.oidc_conformant = true;
clientData.jwt_configuration = {
   alg: 'RS256',
   lifetime_in_seconds: 36000,
};
````
2. Unit tests have been added to `test/tools/applications.test.ts` for the above logic.

The logic introduced in this PR follows the same logic found in Manhattan when creating application: 
https://github.com/atko-cic/manhattan/blob/84d71680cb35db0ed37d2033045a9f117d91a8da/manhattan-services/src/applications/service.ts#L142

### References

Please include relevant links supporting this change such as a:

https://auth0team.atlassian.net/browse/DXAA-603

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

- [x] This change adds unit test coverage
- [ ] This change adds integration test coverage

1. Application Creation w/ Inspector shows both `oidc_conformant` and `jwt_configuration` set:

<img width="2562" height="956" alt="Screenshot 2026-05-04 at 2 23 00 PM" src="https://github.com/user-attachments/assets/4d28cb44-1e62-4b57-bb0c-821905887779" />

2. Manage Dashboard shows the values are set for the application created via the mcp server:

<img width="2562" height="957" alt="Screenshot 2026-05-04 at 2 23 49 PM" src="https://github.com/user-attachments/assets/5b4e0b4b-86f3-4743-a1c5-39c444495bcb" />

These changes can be tested by:
1. Switch to the `feat/DXAA-603-set-oidc-conformant-jwt-config-auth0-create-application` branch
2. Run `npm run build`
3. Initialize the mcp server with the init command: npx . init --client vscode (if using vscode)
4. Open inspector by running `npm run start:inspect`
5. Connect to inspector and create an application
6. The response will show the `oidc_conformant` and `jwt_configuration` output in the success response.

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
