### PR TITLE
feat: expose read-only/tools/analytics/debug via MCPB user_config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ package-lock.json
 # Auth0 credentials
 .env.local
 
+# MCPB bundle output
+*.mcpb
+

--- a/README.md
+++ b/README.md
@@ -258,6 +258,15 @@ npx @auth0/auth0-mcp-server run --tools '*'
 > [!IMPORTANT]
 > When both `--read-only` and `--tools` flags are used together, the `--read-only` flag takes priority for security. This means even if your `--tools` pattern matches non-read-only tools, only read-only operations will be available. This ensures you can rely on the `--read-only` flag as a security guardrail.
 
+For environments where CLI flags cannot be passed through (for example, MCP bundle installs), the same controls are available as environment variables:
+
+| Variable              | Equivalent flag | Example                                    |
+| --------------------- | --------------- | ------------------------------------------ |
+| `AUTH0_MCP_READ_ONLY` | `--read-only`   | `AUTH0_MCP_READ_ONLY=true`                 |
+| `AUTH0_MCP_TOOLS`     | `--tools`       | `AUTH0_MCP_TOOLS=auth0_list_*,auth0_get_*` |
+
+CLI flags take precedence when both are provided.
+
 This approach offers several important benefits:
 
 1. **Enhanced Security**: By limiting available tools to only what's needed, you reduce the potential attack surface and prevent unintended modifications to your Auth0 tenant.

--- a/manifest.json
+++ b/manifest.json
@@ -25,7 +25,11 @@
       "args": ["${__dirname}/dist/index.js", "run"],
       "env": {
         "AUTH0_TOKEN": "${user_config.auth0_token}",
-        "AUTH0_DOMAIN": "${user_config.auth0_domain}"
+        "AUTH0_DOMAIN": "${user_config.auth0_domain}",
+        "AUTH0_MCP_READ_ONLY": "${user_config.read_only}",
+        "AUTH0_MCP_TOOLS": "${user_config.tools}",
+        "AUTH0_MCP_ANALYTICS": "${user_config.analytics}",
+        "DEBUG": "${user_config.debug}"
       }
     }
   },
@@ -134,6 +138,34 @@
       "type": "string",
       "title": "Auth0 Tenant Domain",
       "description": "Optional tenant domain such as your-tenant.auth0.com. If omitted, the server will try to infer it from a JWT access token.",
+      "required": false
+    },
+    "read_only": {
+      "type": "boolean",
+      "title": "Read-only mode",
+      "description": "When enabled, only list and get operations are exposed. All create, update, and deploy tools are filtered out.",
+      "default": false,
+      "required": false
+    },
+    "tools": {
+      "type": "string",
+      "title": "Tool allowlist",
+      "description": "Comma-separated tool names or glob patterns to enable (e.g. auth0_list_*,auth0_get_*). Defaults to * (all tools).",
+      "default": "*",
+      "required": false
+    },
+    "analytics": {
+      "type": "string",
+      "title": "Analytics",
+      "description": "Set to \"false\" to opt out of anonymized analytics collection.",
+      "default": "true",
+      "required": false
+    },
+    "debug": {
+      "type": "string",
+      "title": "Debug namespace",
+      "description": "Set to \"auth0-mcp\" to enable detailed debug logging.",
+      "default": "",
       "required": false
     }
   }

--- a/package.json
+++ b/package.json
@@ -26,6 +26,8 @@
     "prebuild": "npm run format && npm run lint",
     "build": "rm -rf dist && tsc",
     "postbuild": "shx chmod +x dist/*.js",
+    "build:mcpb": "npm run build && npm prune --omit=dev && npx @anthropic-ai/mcpb pack . auth0-mcp-server.mcpb",
+    "postbuild:mcpb": "echo '⚠️  Dev dependencies were pruned. Run npm install to restore them.'",
     "dev": "tsx src/index.ts run",
     "dev:debug": "DEBUG=auth0-mcp tsx src/index.ts run",
     "dev:inspect": "npx @modelcontextprotocol/inspector tsx src/index.ts run",

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -89,13 +89,31 @@ const run = async (options: RunOptions): Promise<void> => {
       log(`Set HOME environment variable to ${process.env.HOME}`);
     }
 
+    // Honor env vars for MCPB-style installs where CLI args are not passed through
+    if (!options.readOnly && process.env.AUTH0_MCP_READ_ONLY === 'true') {
+      options.readOnly = true;
+    }
+    const defaultTools = options.tools.length === 1 && options.tools[0] === '*';
+    if (defaultTools && process.env.AUTH0_MCP_TOOLS) {
+      options.tools = process.env.AUTH0_MCP_TOOLS.split(',')
+        .map((t) => t.trim())
+        .filter(Boolean);
+      if (options.tools.length === 0) {
+        options.tools = ['*'];
+      }
+    }
+
     trackEvent.trackServerRun();
 
-    // Validate authorization before starting server
-    const isAuthorized = await validateAuthorization();
-    if (!isAuthorized) {
-      // Exit with code 1 (standard error code)
-      process.exit(1);
+    // Skip keychain-based validation when credentials are provided via env (MCPB-style launch).
+    // Startup validation in server.ts and per-tool validation still enforce correctness.
+    const envAuth = Boolean(process.env.AUTH0_TOKEN && process.env.AUTH0_DOMAIN);
+    if (!envAuth) {
+      const isAuthorized = await validateAuthorization();
+      if (!isAuthorized) {
+        // Exit with code 1 (standard error code)
+        process.exit(1);
+      }
     }
 
     if (options.readOnly && options.tools.length === 1 && options.tools[0] === '*') {

--- a/test/commands/run.test.ts
+++ b/test/commands/run.test.ts
@@ -202,5 +202,63 @@ describe('Run Module', () => {
       expect(processExitSpy).toHaveBeenCalledWith(1);
       expect(startServer).not.toHaveBeenCalled();
     });
+
+    it('should skip keychain validation when AUTH0_TOKEN and AUTH0_DOMAIN are set', async () => {
+      process.env.AUTH0_TOKEN = 'env-token';
+      process.env.AUTH0_DOMAIN = 'env-tenant.auth0.com';
+      vi.mocked(keychain.getToken).mockResolvedValue(null);
+
+      await run({ tools: ['*'] });
+
+      expect(startServer).toHaveBeenCalled();
+      expect(keychain.getToken).not.toHaveBeenCalled();
+      expect(process.exit).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Env-var overrides (MCPB-style launch)', () => {
+    it('enables read-only mode when AUTH0_MCP_READ_ONLY=true', async () => {
+      process.env.AUTH0_MCP_READ_ONLY = 'true';
+
+      await run({ tools: ['*'] });
+
+      expect(startServer).toHaveBeenCalledWith({ tools: ['*'], readOnly: true });
+    });
+
+    it('does not enable read-only mode when AUTH0_MCP_READ_ONLY is not "true"', async () => {
+      process.env.AUTH0_MCP_READ_ONLY = 'false';
+
+      await run({ tools: ['*'] });
+
+      expect(startServer).toHaveBeenCalledWith({ tools: ['*'] });
+    });
+
+    it('parses AUTH0_MCP_TOOLS into the tools list when no CLI tools were provided', async () => {
+      process.env.AUTH0_MCP_TOOLS = 'auth0_list_*, auth0_get_*';
+
+      await run({ tools: ['*'] });
+
+      expect(startServer).toHaveBeenCalledWith({
+        tools: ['auth0_list_*', 'auth0_get_*'],
+      });
+    });
+
+    it('prefers CLI --tools over AUTH0_MCP_TOOLS', async () => {
+      process.env.AUTH0_MCP_TOOLS = 'auth0_list_*';
+
+      await run({ tools: ['auth0_list_applications'] });
+
+      expect(startServer).toHaveBeenCalledWith({
+        tools: ['auth0_list_applications'],
+      });
+    });
+
+    it('falls back to wildcard when AUTH0_MCP_TOOLS is empty after trimming', async () => {
+      process.env.AUTH0_MCP_TOOLS = ' , , ';
+
+      await run({ tools: ['*'] });
+
+      expect(startServer).toHaveBeenCalledWith({ tools: ['*'] });
+    });
   });
 });


### PR DESCRIPTION
## Summary

Follow-up on #157 to address gaps that surfaced while preparing the Auth0 MCP server for publishing to Smithery.

- Expose `read-only`, `tools`, `analytics`, and `debug` controls via MCPB `user_config` so installers can configure them in the host UI.
- Honor `AUTH0_MCP_READ_ONLY` and `AUTH0_MCP_TOOLS` env vars in the `run` command, since MCPB bundles deliver user config through environment variables (not CLI args).
- Skip keychain-based `validateAuthorization()` when `AUTH0_TOKEN` + `AUTH0_DOMAIN` are provided. Without this, env-backed launches exit at startup because the keychain has no creds. Startup validation in `server.ts` and per-tool `validateConfig()` continue to enforce correctness.
- Add a `build:mcpb` npm script that builds `dist/`, prunes devDependencies, and runs `mcpb pack`. Produces a 3.5 MB bundle (well under Smithery's 25 MB limit).
- Document the new env vars in the Security Best Practices section of the README.
- Ignore `*.mcpb` output artifacts.

## Why the env-var overrides

PR #157 added env-backed config loading (`AUTH0_TOKEN` + `AUTH0_DOMAIN`) but the only way to enable read-only mode or restrict tools was via CLI flags. MCPB hosts (including Smithery) pass user configuration through environment variables at launch time, so those controls need env-var equivalents to remain reachable in a bundled install. CLI flags continue to take precedence when both are provided.

## Test plan

- [x] `npm test` — 356 tests pass (including 6 new tests covering env-var overrides and the keychain-skip path).
- [x] `npx mcpb validate ./manifest.json` — schema passes.
- [x] `npm run build:mcpb` — produces a 3.5 MB bundle (unpacked 11.3 MB, 2665 files, 2017 ignored by `.mcpbignore`).
- [ ] Dry publish via `smithery mcp publish ./auth0-mcp-server.mcpb -n auth0/auth0-mcp-server` once the follow-up is merged into the `mcpb` branch.

## Not addressed

`auth0_token` is intentionally left as `required: false` to preserve the keychain fallback for hosts like Claude Desktop where users have already run `auth0-mcp-server init`. Changing it would force all MCPB hosts (not just Smithery) to re-enter credentials.

