### PR TITLE
[codex] Fix startup logging notification

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,34 @@ gemini extensions install https://github.com/auth0/auth0-mcp-server
 
 ```
 
+**Codex CLI**
+
+Authenticate once with Auth0:
+
+```bash
+npx @auth0/auth0-mcp-server init
+```
+
+Then add the Auth0 MCP server to Codex:
+
+```bash
+codex mcp add auth0 --env DEBUG=auth0-mcp --env DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/1000/bus -- npx -y @auth0/auth0-mcp-server run
+```
+
+You can also add it directly to `~/.codex/config.toml`:
+
+```toml
+[mcp_servers.auth0]
+command = "npx"
+args = ["-y", "@auth0/auth0-mcp-server", "run"]
+
+[mcp_servers.auth0.env]
+DEBUG = "auth0-mcp"
+DBUS_SESSION_BUS_ADDRESS = "unix:path=/run/user/1000/bus"
+```
+
+Restart Codex after updating the configuration.
+
 **Other MCP Clients**
 
 To use Auth0 MCP Server with any other MCP Client, you can manually add this configuration to the client and restart for changes to take effect:

--- a/src/server.ts
+++ b/src/server.ts
@@ -158,7 +158,6 @@ export async function startServer(options?: ServerOptions) {
       const logMsg = `Auth0 MCP Server version ${packageVersion} running on stdio with ${enabledToolsCount}/${totalToolsCount} tools available`;
       logInfo(logMsg);
       log(logMsg);
-      server.sendLoggingMessage({ level: 'info', data: logMsg });
 
       return server;
     } catch (connectError) {

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -94,6 +94,12 @@ describe('Server', () => {
       );
     });
 
+    it('should not emit MCP logging notifications during startup', async () => {
+      await startServer();
+
+      expect(mockSendLoggingMessage).not.toHaveBeenCalled();
+    });
+
     it('should initialize the server with filtered tools', async () => {
       const options = { tools: ['auth0_list_applications'] };
       const server = await startServer(options);


### PR DESCRIPTION
## Summary

This should fix the Codex integration issue where the Auth0 MCP server emits an MCP logging notification during startup before Codex has finished its startup handshake.

Changes:

- Stop sending the startup message through `server.sendLoggingMessage`.
- Keep the existing startup output through the local logger paths.
- Add a regression test that verifies startup does not emit MCP logging notifications.
- Document how to configure Auth0 MCP in Codex.

fixes https://github.com/auth0/auth0-mcp-server/issues/161

## Codex configuration

Authenticate once with Auth0:

```bash
npx @auth0/auth0-mcp-server init
```

Then add the Auth0 MCP server to Codex:

```bash
codex mcp add auth0 --env DEBUG=auth0-mcp --env DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/1000/bus -- npx -y @auth0/auth0-mcp-server run
```

Equivalent `~/.codex/config.toml` configuration:

```toml
[mcp_servers.auth0]
command = "npx"
args = ["-y", "@auth0/auth0-mcp-server", "run"]

[mcp_servers.auth0.env]
DEBUG = "auth0-mcp"
DBUS_SESSION_BUS_ADDRESS = "unix:path=/run/user/1000/bus"
```

## Validation

- `npm test -- test/server.test.ts`
- `npm run typecheck`
- `npm run format:check`
