### PR TITLE
feat: add Claude Code as a supported MCP client

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,19 @@ You can also explicitly select read-only tools:
 npx @auth0/auth0-mcp-server init --tools 'auth0_list_*,auth0_get_*'
 ```
 
+**Claude Code**
+
+Initialize the Auth0 MCP server for Claude Code
+
+```bash
+npx @auth0/auth0-mcp-server init --client claude-code
+```
+
+You will be prompted to choose a configuration scope:
+
+- **User** — written to `~/.claude.json` and available across all your projects.
+- **Project** — written to `.mcp.json` at a project folder you specify, intended to be checked into version control and shared with your team.
+
 **Windsurf**
 
 ```bash

--- a/src/clients/claude-code.ts
+++ b/src/clients/claude-code.ts
@@ -1,0 +1,127 @@
+import * as path from 'path';
+import * as os from 'os';
+import * as fs from 'fs';
+import { BaseClientManager } from './base.js';
+import { promptForChoice, promptForPath } from '../utils/terminal.js';
+import type { ClientOptions } from '../utils/types.js';
+
+/**
+ * Claude Code configuration scope options.
+ *
+ * - `user`: stored in `~/.claude.json`, available across all projects.
+ * - `project`: stored in `.mcp.json` at a project root, shared via version control.
+ */
+export type ClaudeCodeScope = 'user' | 'project';
+
+/**
+ * Extended client options for Claude Code that include scope selection.
+ */
+export interface ClaudeCodeClientOptions extends ClientOptions {
+  scope?: ClaudeCodeScope;
+  workspaceFolder?: string;
+}
+
+/**
+ * Client manager implementation for Claude Code (the Anthropic CLI).
+ *
+ * Supports both user-scoped configuration (`~/.claude.json`) and
+ * project-scoped configuration (`.mcp.json` at a project root). Both scopes
+ * use the standard `mcpServers` key, so the base merge logic is reused.
+ *
+ * @see {@link https://claude.ai/download | Claude Code}
+ */
+export class ClaudeCodeClientManager extends BaseClientManager {
+  private selectedScope: ClaudeCodeScope = 'user';
+  private selectedWorkspaceFolder?: string;
+
+  constructor() {
+    super({
+      clientType: 'claude-code',
+      displayName: 'Claude Code',
+    });
+  }
+
+  /**
+   * Returns the path to the Claude Code configuration file for the selected scope.
+   *
+   * - User scope resolves to `~/.claude.json` (home directory always exists).
+   * - Project scope resolves to `<workspaceFolder>/.mcp.json`.
+   *
+   * @returns The absolute path to the configuration file.
+   */
+  getConfigPath(): string {
+    if (this.selectedScope === 'project') {
+      if (!this.selectedWorkspaceFolder) {
+        // Fallback to user scope if project folder not set
+        return path.join(os.homedir(), '.claude.json');
+      }
+
+      if (!fs.existsSync(this.selectedWorkspaceFolder)) {
+        throw new Error(`Project folder does not exist: ${this.selectedWorkspaceFolder}`);
+      }
+
+      return path.join(this.selectedWorkspaceFolder, '.mcp.json');
+    }
+
+    return path.join(os.homedir(), '.claude.json');
+  }
+
+  /**
+   * Prompts the user to select between user and project scope.
+   *
+   * @returns Promise resolving to the selected scope.
+   */
+  private async promptForScope(): Promise<ClaudeCodeScope> {
+    return promptForChoice(
+      'Where would you like to configure the Auth0 MCP server for Claude Code?',
+      [
+        {
+          label: 'User - Configure for all your projects (~/.claude.json)',
+          value: 'user' as const,
+        },
+        {
+          label: 'Project - Configure for a specific project/repository',
+          value: 'project' as const,
+        },
+      ],
+      'user'
+    );
+  }
+
+  /**
+   * Prompts the user for the project folder path.
+   *
+   * @returns Promise resolving to the validated project folder path.
+   */
+  private async promptForProjectFolder(): Promise<string> {
+    return promptForPath('Enter the absolute path to your project folder: ', {
+      required: true,
+      mustExist: true,
+      mustBeDirectory: true,
+    });
+  }
+
+  /**
+   * Configures Claude Code, prompting for scope (user vs project) when not
+   * supplied. Once the scope and path are resolved, delegates to the base
+   * implementation, which merges the Auth0 server into the `mcpServers` key.
+   *
+   * @param options - Client configuration options.
+   */
+  async configure(options: ClaudeCodeClientOptions): Promise<void> {
+    // Set scope from options or prompt user
+    if (options.scope) {
+      this.selectedScope = options.scope;
+      this.selectedWorkspaceFolder = options.workspaceFolder;
+    } else {
+      this.selectedScope = await this.promptForScope();
+    }
+
+    // If project scope but no folder specified, prompt for it
+    if (this.selectedScope === 'project' && !this.selectedWorkspaceFolder) {
+      this.selectedWorkspaceFolder = await this.promptForProjectFolder();
+    }
+
+    await super.configure(options);
+  }
+}

--- a/src/clients/index.ts
+++ b/src/clients/index.ts
@@ -8,6 +8,7 @@
 
 // Import client classes
 import { ClaudeClientManager } from './claude.js';
+import { ClaudeCodeClientManager } from './claude-code.js';
 import { CursorClientManager } from './cursor.js';
 import { WindsurfClientManager } from './windsurf.js';
 import { VSCodeClientManager } from './vscode.js';
@@ -15,6 +16,7 @@ import { GeminiClientManager } from './gemini.js';
 
 // Create client manager instances
 const claude = new ClaudeClientManager();
+const claudeCode = new ClaudeCodeClientManager();
 const cursor = new CursorClientManager();
 const windsurf = new WindsurfClientManager();
 const vscode = new VSCodeClientManager();
@@ -26,12 +28,14 @@ const gemini = new GeminiClientManager();
  * Each property corresponds to a supported client application.
  *
  * @property {ClaudeClientManager} claude - Manager for Claude Desktop.
+ * @property {ClaudeCodeClientManager} 'claude-code' - Manager for the Claude Code CLI.
  * @property {CursorClientManager} cursor - Manager for Cursor code editor.
  * @property {WindsurfClientManager} windsurf - Manager for Windsurf editor.
  * @property {VSCodeClientManager} vscode - Manager for Visual Studio Code.
  * @property {GeminiClientManager} gemini - Manager for the Gemini CLI.
  *
  * @see {@link https://claude.ai/download | Claude Desktop}
+ * @see {@link https://claude.ai/download | Claude Code}
  * @see {@link https://www.cursor.com/ | Cursor Code Editor}
  * @see {@link https://windsurf.com/editor | Windsurf Editor}
  * @see {@link https://code.visualstudio.com/ | Visual Studio Code}
@@ -39,6 +43,7 @@ const gemini = new GeminiClientManager();
  */
 export const clients = {
   claude,
+  'claude-code': claudeCode,
   cursor,
   windsurf,
   vscode,

--- a/src/clients/types.ts
+++ b/src/clients/types.ts
@@ -5,7 +5,7 @@ import type { ClientOptions } from '../utils/types.js';
  *
  * Represents the set of known MCP client applications supported by this project.
  */
-export type ClientType = 'claude' | 'cursor' | 'windsurf' | 'vscode' | 'gemini';
+export type ClientType = 'claude' | 'claude-code' | 'cursor' | 'windsurf' | 'vscode' | 'gemini';
 
 /**
  * MCP server configuration object used in client configuration files.

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -107,10 +107,10 @@ async function configureClient(clientType: ClientType, options: InitOptions): Pr
  * This function orchestrates the complete initialization process by:
  * 1. Resolving and validating requested scopes
  * 2. Obtaining authorization through the device flow
- * 3. Configuring the selected client (Claude, Windsurf, Cursor, VS Code or Gemini CLI)
+ * 3. Configuring the selected client (Claude, Claude Code, Windsurf, Cursor, VS Code or Gemini CLI)
  *
  * @param {InitOptions} options - Configuration options including:
- *   - client: The target client type to configure ('claude', 'windsurf', 'cursor', 'vscode' or 'gemini)
+ *   - client: The target client type to configure ('claude', 'claude-code', 'windsurf', 'cursor', 'vscode' or 'gemini')
  *   - scopes: Optional scope patterns for authorization (will prompt if omitted)
  *   - tools: Tool patterns to enable (e.g., ['auth0_list_*'])
  *   - (no-)interaction: Should the CLI prompt the user to press return to open the browser

--- a/src/index.ts
+++ b/src/index.ts
@@ -83,7 +83,7 @@ program
   .description('Initialize the server (authenticate and configure)')
   .option(
     '--client <client>',
-    'Configure specific client (claude, windsurf, cursor, vscode or gemini)',
+    'Configure specific client (claude, claude-code, windsurf, cursor, vscode or gemini)',
     'claude'
   )
   .option(

--- a/test/clients/claude-code.test.ts
+++ b/test/clients/claude-code.test.ts
@@ -1,0 +1,194 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import * as path from 'path';
+import * as os from 'os';
+import * as fs from 'fs';
+
+// Mock dependencies
+vi.mock('path');
+vi.mock('os');
+vi.mock('fs');
+vi.mock('../../src/utils/logger.js', () => ({
+  log: vi.fn(),
+}));
+vi.mock('../../src/utils/terminal.js', () => ({
+  cliOutput: vi.fn(),
+  promptForChoice: vi.fn(),
+  promptForPath: vi.fn(),
+}));
+
+// Import after mocks
+import { ClaudeCodeClientManager } from '../../src/clients/claude-code.js';
+import { cliOutput, promptForChoice, promptForPath } from '../../src/utils/terminal.js';
+import type { ClaudeCodeClientOptions } from '../../src/clients/claude-code.js';
+
+describe('ClaudeCodeClientManager', () => {
+  let manager: ClaudeCodeClientManager;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    manager = new ClaudeCodeClientManager();
+
+    vi.mocked(os.homedir).mockReturnValue('/home/user');
+    vi.mocked(path.join).mockImplementation((...segments) => segments.join('/'));
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    vi.mocked(fs.readFileSync).mockReturnValue('{}');
+    vi.mocked(fs.writeFileSync).mockImplementation(() => {});
+  });
+
+  describe('Constructor', () => {
+    it('should initialize with correct client type and display name', () => {
+      expect(manager.displayName).toBe('Claude Code');
+    });
+  });
+
+  describe('getConfigPath - User scope', () => {
+    it('should resolve to ~/.claude.json by default', () => {
+      const configPath = manager.getConfigPath();
+
+      expect(path.join).toHaveBeenCalledWith('/home/user', '.claude.json');
+      expect(configPath).toBe('/home/user/.claude.json');
+    });
+  });
+
+  describe('getConfigPath - Project scope', () => {
+    it('should resolve to <folder>/.mcp.json when project scope is selected', async () => {
+      const projectFolder = '/path/to/project';
+      vi.mocked(fs.existsSync).mockImplementation((p) => p === projectFolder);
+
+      await manager.configure({
+        scope: 'project',
+        workspaceFolder: projectFolder,
+        tools: ['applications'],
+      });
+
+      const configPath = manager.getConfigPath();
+
+      expect(path.join).toHaveBeenCalledWith(projectFolder, '.mcp.json');
+      expect(configPath).toBe('/path/to/project/.mcp.json');
+    });
+
+    it('should throw when project folder does not exist', async () => {
+      const projectFolder = '/nonexistent/project';
+      vi.mocked(fs.existsSync).mockImplementation((p) => p !== projectFolder);
+
+      await expect(
+        manager.configure({
+          scope: 'project',
+          workspaceFolder: projectFolder,
+          tools: ['applications'],
+        })
+      ).rejects.toThrow(`Project folder does not exist: ${projectFolder}`);
+    });
+
+    it('getConfigPath falls back to ~/.claude.json when project folder is unset', async () => {
+      await manager.configure({
+        scope: 'project',
+        // no workspaceFolder
+        tools: ['applications'],
+      });
+
+      // Project scope with no folder prompts the user for one
+      expect(promptForPath).toHaveBeenCalled();
+
+      const configPath = manager.getConfigPath();
+      expect(configPath).toBe('/home/user/.claude.json');
+    });
+  });
+
+  describe('configure - Scope selection', () => {
+    const testOptions: ClaudeCodeClientOptions = {
+      tools: ['applications'],
+      readOnly: false,
+    };
+
+    it('should prompt for scope when not provided, defaulting to user', async () => {
+      vi.mocked(promptForChoice).mockResolvedValue('user');
+
+      await manager.configure(testOptions);
+
+      expect(promptForChoice).toHaveBeenCalledWith(
+        'Where would you like to configure the Auth0 MCP server for Claude Code?',
+        [
+          {
+            label: 'User - Configure for all your projects (~/.claude.json)',
+            value: 'user',
+          },
+          {
+            label: 'Project - Configure for a specific project/repository',
+            value: 'project',
+          },
+        ],
+        'user'
+      );
+      expect(promptForPath).not.toHaveBeenCalled();
+    });
+
+    it('should prompt for project folder when project scope is chosen', async () => {
+      const projectFolder = '/path/to/project';
+      vi.mocked(promptForChoice).mockResolvedValue('project');
+      vi.mocked(promptForPath).mockResolvedValue(projectFolder);
+      vi.mocked(fs.existsSync).mockImplementation((p) => p === projectFolder);
+
+      await manager.configure(testOptions);
+
+      expect(promptForPath).toHaveBeenCalledWith(
+        'Enter the absolute path to your project folder: ',
+        {
+          required: true,
+          mustExist: true,
+          mustBeDirectory: true,
+        }
+      );
+    });
+
+    it('should use scope from options without prompting', async () => {
+      const projectFolder = '/provided/project';
+      vi.mocked(fs.existsSync).mockImplementation((p) => p === projectFolder);
+
+      await manager.configure({
+        ...testOptions,
+        scope: 'project',
+        workspaceFolder: projectFolder,
+      });
+
+      expect(promptForChoice).not.toHaveBeenCalled();
+      expect(promptForPath).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('configure - mcpServers format', () => {
+    it('should write the auth0 server under the mcpServers key', async () => {
+      vi.mocked(promptForChoice).mockResolvedValue('user');
+
+      await manager.configure({ tools: ['applications'] });
+
+      const writeCall = vi.mocked(fs.writeFileSync).mock.calls[0];
+      const writtenConfig = JSON.parse(writeCall[1] as string);
+
+      expect(writtenConfig).toHaveProperty('mcpServers');
+      expect(writtenConfig.mcpServers).toHaveProperty('auth0');
+      expect(writtenConfig.mcpServers.auth0).toHaveProperty('command', 'npx');
+      expect(cliOutput).toHaveBeenCalled();
+    });
+
+    it('should preserve existing top-level keys in ~/.claude.json', async () => {
+      const existingConfig = {
+        projects: { '/some/project': { mcpServers: {} } },
+        mcpServers: {
+          'other-server': { command: 'other-command', args: [] },
+        },
+      };
+      vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify(existingConfig));
+      vi.mocked(promptForChoice).mockResolvedValue('user');
+
+      await manager.configure({ tools: ['applications'] });
+
+      const writeCall = vi.mocked(fs.writeFileSync).mock.calls[0];
+      const writtenConfig = JSON.parse(writeCall[1] as string);
+
+      expect(writtenConfig).toHaveProperty('projects');
+      expect(writtenConfig.mcpServers).toHaveProperty('other-server');
+      expect(writtenConfig.mcpServers).toHaveProperty('auth0');
+    });
+  });
+});

--- a/test/clients/clients.test.ts
+++ b/test/clients/clients.test.ts
@@ -78,6 +78,9 @@ describe('Client Implementations', () => {
 
       expect(clients.vscode).toHaveProperty('getConfigPath');
       expect(clients.vscode).toHaveProperty('configure');
+
+      expect(clients['claude-code']).toHaveProperty('getConfigPath');
+      expect(clients['claude-code']).toHaveProperty('configure');
     });
 
     it('should initialize with correct client types and display names', () => {
@@ -93,6 +96,9 @@ describe('Client Implementations', () => {
 
       expect(clients.vscode).toHaveProperty('clientType', 'vscode');
       expect(clients.vscode).toHaveProperty('displayName', 'VS Code');
+
+      expect(clients['claude-code']).toHaveProperty('clientType', 'claude-code');
+      expect(clients['claude-code']).toHaveProperty('displayName', 'Claude Code');
     });
   });
 
@@ -147,6 +153,14 @@ describe('Client Implementations', () => {
         })
       );
       expect(ensureDir).toHaveBeenCalled();
+    });
+
+    it('should resolve user-scope config path for Claude Code', () => {
+      // Act: defaults to user scope (~/.claude.json)
+      const configPath = clients['claude-code'].getConfigPath();
+
+      // Assert
+      expect(configPath).toContain('.claude.json');
     });
   });
 

--- a/test/clients/index.test.ts
+++ b/test/clients/index.test.ts
@@ -37,6 +37,15 @@ vi.mock('../../src/clients/vscode.js', () => ({
   }),
 }));
 
+vi.mock('../../src/clients/claude-code.js', () => ({
+  ClaudeCodeClientManager: vi.fn(function () {
+    return {
+      getConfigPath: vi.fn(),
+      configure: vi.fn(),
+    };
+  }),
+}));
+
 // Act: Import the module under test after mocking dependencies
 import * as clientsIndex from '../../src/clients/index.js';
 
@@ -52,6 +61,7 @@ describe('Client Module Index', () => {
     expect(clientsIndex.clients).toHaveProperty('cursor');
     expect(clientsIndex.clients).toHaveProperty('windsurf');
     expect(clientsIndex.clients).toHaveProperty('vscode');
+    expect(clientsIndex.clients).toHaveProperty('claude-code');
 
     // Assert: Verify that each client manager instance has the expected methods
     expect(clientsIndex.clients.claude).toHaveProperty('getConfigPath');
@@ -62,5 +72,7 @@ describe('Client Module Index', () => {
     expect(clientsIndex.clients.windsurf).toHaveProperty('configure');
     expect(clientsIndex.clients.vscode).toHaveProperty('getConfigPath');
     expect(clientsIndex.clients.vscode).toHaveProperty('configure');
+    expect(clientsIndex.clients['claude-code']).toHaveProperty('getConfigPath');
+    expect(clientsIndex.clients['claude-code']).toHaveProperty('configure');
   });
 });

--- a/test/commands/init-client-credentials.test.ts
+++ b/test/commands/init-client-credentials.test.ts
@@ -43,6 +43,10 @@ vi.mock('../../src/clients/index', () => ({
       displayName: 'Cursor',
       configure: vi.fn().mockResolvedValue(undefined),
     },
+    'claude-code': {
+      displayName: 'Claude Code',
+      configure: vi.fn().mockResolvedValue(undefined),
+    },
   },
 }));
 

--- a/test/commands/init.test.ts
+++ b/test/commands/init.test.ts
@@ -26,11 +26,17 @@ vi.mock('../../src/clients/index.js', () => {
     configure: vi.fn().mockResolvedValue(undefined),
   };
 
+  const mockClaudeCodeManager = {
+    getConfigPath: vi.fn(),
+    configure: vi.fn().mockResolvedValue(undefined),
+  };
+
   return {
     clients: {
       claude: mockClaudeManager,
       cursor: mockCursorManager,
       windsurf: mockWindsurfManager,
+      'claude-code': mockClaudeCodeManager,
     },
   };
 });
@@ -60,6 +66,7 @@ describe('Init Module', () => {
   const mockedClaudeConfigure = vi.mocked(clients.claude.configure);
   const mockedWindsurfConfigure = vi.mocked(clients.windsurf.configure);
   const mockedCursorConfigure = vi.mocked(clients.cursor.configure);
+  const mockedClaudeCodeConfigure = vi.mocked(clients['claude-code'].configure);
   const mockedLog = vi.mocked(log);
   const mockedPromptForScopeSelection = vi.mocked(promptForScopeSelection);
 
@@ -142,6 +149,7 @@ describe('Init Module', () => {
     it.each([
       ['windsurf', mockedWindsurfConfigure],
       ['cursor', mockedCursorConfigure],
+      ['claude-code', mockedClaudeCodeConfigure],
     ])('should initialize %s client when specified', async (clientType, configMock) => {
       // Act
       await init({ client: clientType as ClientType, tools: ['*'] });
@@ -155,6 +163,7 @@ describe('Init Module', () => {
         mockedClaudeConfigure,
         mockedWindsurfConfigure,
         mockedCursorConfigure,
+        mockedClaudeCodeConfigure,
       ];
       const otherMocks = allClientMocks.filter((mock) => mock !== configMock);
       otherMocks.forEach((mock) => {

--- a/test/utils/onboarding.test.ts
+++ b/test/utils/onboarding.test.ts
@@ -229,19 +229,13 @@ describe('hasNonVerifiableCallbacks', () => {
 
   it('returns true if any callback is non-verifiable', () => {
     expect(
-      hasNonVerifiableCallbacks([
-        'https://example.com/callback',
-        'http://localhost:3000/callback',
-      ])
+      hasNonVerifiableCallbacks(['https://example.com/callback', 'http://localhost:3000/callback'])
     ).toBe(true);
   });
 
   it('returns false when all callbacks are verifiable', () => {
     expect(
-      hasNonVerifiableCallbacks([
-        'https://example.com/callback',
-        'https://app.example.com/auth',
-      ])
+      hasNonVerifiableCallbacks(['https://example.com/callback', 'https://app.example.com/auth'])
     ).toBe(false);
   });
 });


### PR DESCRIPTION
### Changes

Adds **Claude Code** (the Anthropic CLI) as a sixth supported MCP client for the `init` command, alongside Claude Desktop, Cursor, Windsurf, VS Code, and Gemini.

- **New class** `ClaudeCodeClientManager` (`src/clients/claude-code.ts`) extending `BaseClientManager`. It overrides `configure()` to prompt for a configuration scope, then delegates to the base merge logic since both scopes use the standard `mcpServers` key:
  - **User scope** → `~/.claude.json` (available across all projects). Default when prompted.
  - **Project scope** → `.mcp.json` at a user-specified project folder (shared via version control).
- **Registry** (`src/clients/index.ts`): registered under the key `'claude-code'` — the key must equal the `ClientType` string exactly, since `init` resolves managers via `clients[clientType]`.
- **Type** (`src/clients/types.ts`): added `'claude-code'` to the `ClientType` union.
- **CLI** (`src/index.ts`, `src/commands/init.ts`): added `claude-code` to the `--client` help text, an example invocation, and JSDoc.
- **Docs** (`README.md`): new "Claude Code" section documenting `init --client claude-code` and the user-vs-project scope prompt.

Config format written matches what Claude Code expects for a stdio server (verified against the [Claude Code MCP docs](https://code.claude.com/docs/en/mcp)):

```json
{
  "mcpServers": {
    "auth0": {
      "command": "npx",
      "args": ["-y", "@auth0/auth0-mcp-server", "run", "--tools", "*"],
      "env": { "DEBUG": "auth0-mcp" }
    }
  }
}
```

**Usage**

```bash
npx @auth0/auth0-mcp-server init --client claude-code
```

### References

- Jira: https://auth0team.atlassian.net/browse/DXAA-619

### Testing

Verified with both automated tests and a manual end-to-end run against a real Auth0 tenant and a live Claude Code install.

**Automated:** `npm run build`, `npm run typecheck`, `npm run lint`, and `npm test` all pass (388 tests, 35 files). New suite `test/clients/claude-code.test.ts` covers: default user-scope path resolution; project-scope path resolution; throw when the project folder does not exist; `getConfigPath` fallback when no folder is set; the scope prompt (default `user`); the project-folder prompt; and that the `mcpServers` merge preserves pre-existing top-level keys in `~/.claude.json`. Existing `init`/registry suites were extended to include the new client.

**Manual end-to-end (real CLI, real tenant):**

1. **Project scope** — ran `node dist/index.js init --client claude-code --scopes 'read:clients'`, completed the device-auth browser login, chose **Project**, and entered a project folder. Confirmed `<folder>/.mcp.json` was written with the `auth0` entry under `mcpServers`.
2. **User scope** — re-ran the same command, chose **User**. Confirmed the `auth0` entry was merged into `~/.claude.json` under `mcpServers`, and that all pre-existing servers (asana, atlassian, github, lucid, playwright, slack, zoom) and ~40 other top-level keys (`projects`, `userID`, etc.) were preserved untouched.
3. **Live connection** — ran `claude mcp list` from the project directory and confirmed `auth0: npx -y @auth0/auth0-mcp-server run --tools * - ✓ Connected`, proving Claude Code actually loads and connects to the configured server. (Project-scope `.mcp.json` takes precedence over the user-scope entry in that directory, per Claude Code's documented scope hierarchy.)

- [x] This change adds unit test coverage
- [ ] This change adds integration test coverage

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
