### PR TITLE
feat: add auth0_get_quickstart_guide tool (DXAA-555)

### DIFF
--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -4,6 +4,7 @@ import { APPLICATION_GRANTS_HANDLERS, APPLICATION_GRANTS_TOOLS } from './applica
 import type { HandlerConfig, HandlerRequest, HandlerResponse, Tool } from '../utils/types.js';
 import { FORM_HANDLERS, FORM_TOOLS } from './forms.js';
 import { LOG_HANDLERS, LOG_TOOLS } from './logs.js';
+import { QUICKSTART_HANDLERS, QUICKSTART_TOOLS } from './quickstarts.js';
 import { RESOURCE_SERVER_HANDLERS, RESOURCE_SERVER_TOOLS } from './resource-servers.js';
 import trackEvent from '../utils/analytics.js';
 
@@ -15,6 +16,7 @@ export const TOOLS: Tool[] = [
   ...LOG_TOOLS,
   ...FORM_TOOLS,
   ...APPLICATION_GRANTS_TOOLS,
+  ...QUICKSTART_TOOLS,
 ];
 
 // Collect all handlers
@@ -25,6 +27,7 @@ const allHandlers = {
   ...LOG_HANDLERS,
   ...FORM_HANDLERS,
   ...APPLICATION_GRANTS_HANDLERS,
+  ...QUICKSTART_HANDLERS,
 };
 
 /**

--- a/src/tools/quickstarts.ts
+++ b/src/tools/quickstarts.ts
@@ -194,6 +194,8 @@ export const QUICKSTART_HANDLERS: Record<
       port,
       appDomain: baseUrlParsed.hostname,
       appScheme: baseUrlParsed.protocol.replace(':', ''),
+      auth0ClientSecret: "*******MASKED*********",
+      sessionCookieSecret: "*******MASKED*********",
     };
 
     for (const [key, def] of Object.entries(spec.inputs)) {

--- a/src/tools/quickstarts.ts
+++ b/src/tools/quickstarts.ts
@@ -1,0 +1,273 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import type { HandlerConfig, HandlerRequest, HandlerResponse, Tool } from '../utils/types.js';
+import { log } from '../utils/logger.js';
+import { createErrorResponse, createSuccessResponse } from '../utils/http-utility.js';
+import { fetchQuickstartSpec } from '../utils/quickstarts.js';
+import { resolveCallbackUrls } from '../utils/onboarding.js';
+import { fetchWithOptions } from '../utils/fetch.js';
+import { calculateUrlUpdates, resolvePlaceholders } from '../utils/quickstart-guide.js';
+import { APPLICATION_HANDLERS } from './applications.js';
+
+const VALID_FRAMEWORKS = ['react', 'vue', 'angular', 'nextjs'];
+
+export const QUICKSTART_TOOLS: Tool[] = [
+  {
+    name: 'auth0_get_quickstart_guide',
+    description:
+      'Fetch and return the Auth0 quickstart implementation prompt for a specific framework. ' +
+      'Resolves callback URLs from the project configuration and updates them on the Auth0 ' +
+      'application. Fetches the quickstart prompt from CDN and injects runtime values. ' +
+      "The returned prompt contains code that should be implemented in the user's project. " +
+      'If you have file-write capabilities, implement the code directly at project_path. ' +
+      'If you do not have file-write capabilities, present the code to the user with clear ' +
+      'instructions for where each file should be created or modified. ' +
+      'Requires client_id, framework, and project_path. If the application does not exist, call auth0_onboarding first.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        client_id: {
+          type: 'string',
+          description: 'Auth0 application client_id',
+        },
+        framework: {
+          type: 'string',
+          enum: VALID_FRAMEWORKS,
+          description: 'JavaScript framework for the quickstart',
+        },
+        project_path: {
+          type: 'string',
+          description:
+            'Path to the project directory. Used for .env file check and project config port detection.',
+        },
+        base_url: {
+          type: 'string',
+          description:
+            'Explicit base URL override for callback resolution (e.g. http://localhost:3000)',
+        },
+      },
+      required: ['client_id', 'framework', 'project_path'],
+    },
+    _meta: {
+      requiredScopes: ['read:clients', 'update:clients'],
+      localOnly: true,
+    },
+    annotations: {
+      title: 'Get Quickstart Guide',
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
+  },
+];
+
+export const QUICKSTART_HANDLERS: Record<
+  string,
+  (request: HandlerRequest, config: HandlerConfig) => Promise<HandlerResponse>
+> = {
+  auth0_get_quickstart_guide: async (
+    request: HandlerRequest,
+    config: HandlerConfig
+  ): Promise<HandlerResponse> => {
+    const {
+      client_id: clientId,
+      framework,
+      project_path: projectPath,
+      base_url: baseUrl,
+    } = request.parameters;
+
+    if (!clientId) {
+      return createErrorResponse('Error: client_id is required');
+    }
+    if (!framework) {
+      return createErrorResponse('Error: framework is required');
+    }
+    if (!VALID_FRAMEWORKS.includes(framework)) {
+      return createErrorResponse(
+        `Error: Unsupported framework "${framework}". Must be one of: ${VALID_FRAMEWORKS.join(', ')}`
+      );
+    }
+
+    if (!projectPath) {
+      return createErrorResponse('Error: project_path is required');
+    }
+    const resolvedProjectPath = path.resolve(projectPath);
+    if (resolvedProjectPath !== projectPath && projectPath.includes('..')) {
+      return createErrorResponse('Error: project_path must not contain path traversal sequences');
+    }
+    if (!fs.statSync(resolvedProjectPath, { throwIfNoEntry: false })?.isDirectory()) {
+      return createErrorResponse('Error: project_path must be an existing directory');
+    }
+
+    if (!request.token) {
+      log('Warning: Token is empty or undefined');
+      return createErrorResponse('Error: Missing authorization token');
+    }
+    if (!config.domain) {
+      log('Error: Auth0 domain is not configured');
+      return createErrorResponse('Error: Auth0 domain is not configured');
+    }
+
+    // Step 1: Resolve quickstart spec
+    const spec = await fetchQuickstartSpec(framework);
+    if (!spec) {
+      return createErrorResponse(
+        `Error: Quickstart definition unavailable for framework "${framework}". ` +
+          'The framework may not be supported or the CDN may be temporarily unavailable.'
+      );
+    }
+
+    if (!spec.llmPromptUrl) {
+      return createErrorResponse(
+        `Error: Quickstart definition for "${framework}" does not include an LLM prompt URL.`
+      );
+    }
+
+    // Step 2: Validate application exists
+    const getResponse = await APPLICATION_HANDLERS['auth0_get_application'](
+      { token: request.token, parameters: { client_id: clientId } },
+      config
+    );
+    if (getResponse.isError) {
+      return getResponse;
+    }
+
+    let appData: Record<string, any>;
+    try {
+      appData = JSON.parse(getResponse.content[0]?.text ?? '');
+    } catch {
+      return createErrorResponse('Error: Failed to parse application data');
+    }
+
+    // Step 3: Check .env file exists (only when spec has envSnippet)
+    if (spec.envSnippet) {
+      const envFilePath = path.join(resolvedProjectPath, spec.envSnippet.fileName);
+      if (!fs.existsSync(envFilePath)) {
+        return createErrorResponse(
+          `Error: Environment file not found at "${envFilePath}". ` +
+            'Please call auth0_save_credentials_to_file first to set up your environment file.'
+        );
+      }
+    }
+
+    // Step 4: Resolve callback URLs
+    const resolvedUrls = resolveCallbackUrls(spec, baseUrl);
+
+    // Step 5: Fetch LLM prompt
+    let promptText: string;
+    try {
+      const promptResponse = await fetchWithOptions(spec.llmPromptUrl, { retries: 1 });
+      if (!promptResponse.ok) {
+        log(`Failed to fetch LLM prompt from ${spec.llmPromptUrl}: ${promptResponse.status}`);
+        return createErrorResponse(
+          `Error: Quickstart guide unavailable for "${framework}". ` +
+            `Failed to fetch LLM prompt from CDN (status: ${promptResponse.status}).`
+        );
+      }
+      promptText = await promptResponse.text();
+    } catch (error) {
+      log(`Error fetching LLM prompt: ${error}`);
+      return createErrorResponse(
+        `Error: Quickstart guide unavailable for "${framework}". ` +
+          'Failed to fetch LLM prompt from CDN due to a network error.'
+      );
+    }
+
+    // Step 6: Inject runtime values
+    let baseUrlParsed: URL;
+    try {
+      baseUrlParsed = new URL(resolvedUrls.base_url);
+    } catch {
+      return createErrorResponse(`Error: Invalid resolved base URL: ${resolvedUrls.base_url}`);
+    }
+
+    const specDefaultPort = spec.defaultAppOrigin?.port;
+    const port =
+      baseUrlParsed.port ||
+      (specDefaultPort !== undefined ? String(specDefaultPort) : null) ||
+      (baseUrlParsed.protocol === 'https:' ? '443' : '80');
+
+    const inputValues: Record<string, string> = {
+      auth0Domain: config.domain,
+      auth0ClientId: clientId,
+      port,
+      appDomain: baseUrlParsed.hostname,
+      appScheme: baseUrlParsed.protocol.replace(':', ''),
+    };
+
+    for (const [key, def] of Object.entries(spec.inputs)) {
+      if (inputValues[key] === undefined && def && typeof def === 'object' && 'default' in def) {
+        inputValues[key] = String((def as Record<string, unknown>).default);
+      }
+    }
+
+    const resolvedPrompt = resolvePlaceholders(
+      promptText,
+      spec.placeholders,
+      inputValues,
+      spec.environment
+    );
+
+    // Step 7: Update application after all failure-prone non-mutating work succeeds
+    const { updatePayload, finalUrls } = calculateUrlUpdates(resolvedUrls, appData);
+
+    if (updatePayload) {
+      const updateResponse = await APPLICATION_HANDLERS['auth0_update_application'](
+        { token: request.token, parameters: { client_id: clientId, ...updatePayload } },
+        config
+      );
+      if (updateResponse.isError) {
+        const errorDetail = updateResponse.content?.[0]?.text || 'Unknown error';
+        return createErrorResponse(
+          `Error: Failed to update application callback URLs. ${errorDetail}`
+        );
+      }
+    }
+
+    // Step 8: Return response
+    const configuredUrls: Record<string, any> = {
+      callbacks: finalUrls.callbacks,
+      allowed_logout_urls: finalUrls.allowed_logout_urls,
+    };
+    if (finalUrls.web_origins) {
+      configuredUrls.web_origins = finalUrls.web_origins;
+    }
+    if (finalUrls.skip_non_verifiable_callback_uri_confirmation_prompt) {
+      configuredUrls.skip_non_verifiable_callback_uri_confirmation_prompt = true;
+    }
+
+    const actionsTaken: string[] = [];
+    if (updatePayload !== null) {
+      if (finalUrls.callbacks?.length) {
+        actionsTaken.push(`Set callback URL(s): ${finalUrls.callbacks.join(', ')}`);
+      }
+      if (finalUrls.allowed_logout_urls?.length) {
+        actionsTaken.push(`Set logout URL(s): ${finalUrls.allowed_logout_urls.join(', ')}`);
+      }
+      if (finalUrls.web_origins?.length) {
+        actionsTaken.push(`Set allowed web origin(s): ${finalUrls.web_origins.join(', ')}`);
+      }
+    }
+    actionsTaken.push(`Fetched quickstart guide for ${framework}`);
+
+    return createSuccessResponse({
+      success: true,
+      client_id: clientId,
+      framework,
+      project_path: projectPath,
+      app_type: spec.appType,
+      quickstart_prompt: resolvedPrompt,
+      configured_urls: configuredUrls,
+      urls_updated: updatePayload !== null,
+      url_source: resolvedUrls.url_source,
+      actions_taken: actionsTaken,
+      instructions:
+        `First, summarize actions_taken to the user so they know what was configured on their Auth0 application. ` +
+        `Then implement the code from quickstart_prompt in the user's project at project_path. ` +
+        `If you have file-write capabilities, create and modify files directly. ` +
+        `If you do not have file-write capabilities, present each code block to the user ` +
+        `with the file path where it should be created or modified.`,
+    });
+  },
+};

--- a/src/tools/quickstarts.ts
+++ b/src/tools/quickstarts.ts
@@ -279,7 +279,7 @@ export const QUICKSTART_HANDLERS: Record<
       success: true,
       client_id: clientId,
       framework,
-      project_path: projectPath,
+      project_path: resolvedProjectPath,
       app_type: spec.appType,
       quickstart_prompt: resolvedPrompt,
       configured_urls: configuredUrls,

--- a/src/tools/quickstarts.ts
+++ b/src/tools/quickstarts.ts
@@ -278,7 +278,7 @@ export const QUICKSTART_HANDLERS: Record<
     actionsTaken.push(`Fetched quickstart guide for ${framework}`);
 
     const credentialsNote = envFilePath
-      ? ` Auth0 credentials are already saved to "${envFilePath}". Use that file as-is and skip ` +
+      ? `An existing environment file was detected at "${envFilePath}"; use it as-is and skip ` +
         `any environment-variable or .env setup steps in the quickstart_prompt; do not create or copy a new .env file.`
       : '';
 

--- a/src/tools/quickstarts.ts
+++ b/src/tools/quickstarts.ts
@@ -59,7 +59,7 @@ export const QUICKSTART_TOOLS: Tool[] = [
     annotations: {
       title: 'Get Quickstart Guide',
       readOnlyHint: false,
-      destructiveHint: false,
+      destructiveHint: true,
       idempotentHint: true,
       openWorldHint: true,
     },

--- a/src/tools/quickstarts.ts
+++ b/src/tools/quickstarts.ts
@@ -16,7 +16,7 @@ import { APPLICATION_HANDLERS } from './applications.js';
 
 export const QUICKSTART_TOOLS: Tool[] = [
   {
-    name: 'auth0_get_quickstart_guide',
+    name: 'auth0_configure_and_get_quickstart_guide',
     description:
       'Fetch and return the Auth0 quickstart implementation prompt for a specific framework. ' +
       'Resolves callback URLs from the project configuration and updates them on the Auth0 ' +
@@ -70,7 +70,7 @@ export const QUICKSTART_HANDLERS: Record<
   string,
   (request: HandlerRequest, config: HandlerConfig) => Promise<HandlerResponse>
 > = {
-  auth0_get_quickstart_guide: async (
+  auth0_configure_and_get_quickstart_guide: async (
     request: HandlerRequest,
     config: HandlerConfig
   ): Promise<HandlerResponse> => {

--- a/src/tools/quickstarts.ts
+++ b/src/tools/quickstarts.ts
@@ -16,7 +16,7 @@ import { APPLICATION_HANDLERS } from './applications.js';
 
 export const QUICKSTART_TOOLS: Tool[] = [
   {
-    name: 'auth0_configure_and_get_quickstart_guide',
+    name: 'auth0_get_quickstart_guide',
     description:
       'Fetch and return the Auth0 quickstart implementation prompt for a specific framework. ' +
       'Resolves callback URLs from the project configuration and updates them on the Auth0 ' +
@@ -70,7 +70,7 @@ export const QUICKSTART_HANDLERS: Record<
   string,
   (request: HandlerRequest, config: HandlerConfig) => Promise<HandlerResponse>
 > = {
-  auth0_configure_and_get_quickstart_guide: async (
+  auth0_get_quickstart_guide: async (
     request: HandlerRequest,
     config: HandlerConfig
   ): Promise<HandlerResponse> => {

--- a/src/tools/quickstarts.ts
+++ b/src/tools/quickstarts.ts
@@ -4,13 +4,15 @@ import type { HandlerConfig, HandlerRequest, HandlerResponse, Tool } from '../ut
 import { log } from '../utils/logger.js';
 import { createErrorResponse, createSuccessResponse } from '../utils/http-utility.js';
 import { fetchQuickstartSpec } from '../utils/quickstarts.js';
-import { resolveCallbackUrls } from '../utils/onboarding.js';
+import {
+  resolveCallbackUrls,
+  isFrameworkSupported,
+  SUPPORTED_FRAMEWORKS,
+} from '../utils/onboarding.js';
 import { fetchWithOptions } from '../utils/fetch.js';
 import { calculateUrlUpdates, resolvePlaceholders } from '../utils/quickstart-guide.js';
 import { detectExistingEnvFile } from '../utils/credentials-writer.js';
 import { APPLICATION_HANDLERS } from './applications.js';
-
-const VALID_FRAMEWORKS = ['react', 'vue', 'angular', 'nextjs'];
 
 export const QUICKSTART_TOOLS: Tool[] = [
   {
@@ -33,7 +35,7 @@ export const QUICKSTART_TOOLS: Tool[] = [
         },
         framework: {
           type: 'string',
-          enum: VALID_FRAMEWORKS,
+          enum: SUPPORTED_FRAMEWORKS,
           description: 'JavaScript framework for the quickstart',
         },
         project_path: {
@@ -84,9 +86,9 @@ export const QUICKSTART_HANDLERS: Record<
     if (!framework) {
       return createErrorResponse('Error: framework is required');
     }
-    if (!VALID_FRAMEWORKS.includes(framework)) {
+    if (!isFrameworkSupported(framework)) {
       return createErrorResponse(
-        `Error: Unsupported framework "${framework}". Must be one of: ${VALID_FRAMEWORKS.join(', ')}`
+        `Error: Unsupported framework "${framework}". Must be one of: ${SUPPORTED_FRAMEWORKS.join(', ')}`
       );
     }
 

--- a/src/tools/quickstarts.ts
+++ b/src/tools/quickstarts.ts
@@ -269,6 +269,11 @@ export const QUICKSTART_HANDLERS: Record<
       if (finalUrls.web_origins?.length) {
         actionsTaken.push(`Set allowed web origin(s): ${finalUrls.web_origins.join(', ')}`);
       }
+      if (finalUrls.skip_non_verifiable_callback_uri_confirmation_prompt) {
+        actionsTaken.push(
+          'Enabled skip_non_verifiable_callback_uri_confirmation_prompt because a non-verifiable (custom scheme or localhost) callback URL was configured'
+        );
+      }
     }
     actionsTaken.push(`Fetched quickstart guide for ${framework}`);
 

--- a/src/tools/quickstarts.ts
+++ b/src/tools/quickstarts.ts
@@ -61,7 +61,7 @@ export const QUICKSTART_TOOLS: Tool[] = [
       readOnlyHint: false,
       destructiveHint: false,
       idempotentHint: true,
-      openWorldHint: false,
+      openWorldHint: true,
     },
   },
 ];

--- a/src/tools/quickstarts.ts
+++ b/src/tools/quickstarts.ts
@@ -25,7 +25,8 @@ export const QUICKSTART_TOOLS: Tool[] = [
       'If you have file-write capabilities, implement the code directly at project_path. ' +
       'If you do not have file-write capabilities, present the code to the user with clear ' +
       'instructions for where each file should be created or modified. ' +
-      'Requires client_id, framework, and project_path. If the application does not exist, call auth0_onboarding first.',
+      'Requires client_id, framework, and project_path. If the application does not exist, call auth0_onboarding first. ' +
+      'After updating, always inform the user about any automatically applied settings (such as skip_non_verifiable_callback_uri_confirmation_prompt).',
     inputSchema: {
       type: 'object',
       properties: {
@@ -58,7 +59,7 @@ export const QUICKSTART_TOOLS: Tool[] = [
     annotations: {
       title: 'Get Quickstart Guide',
       readOnlyHint: false,
-      destructiveHint: true,
+      destructiveHint: false,
       idempotentHint: true,
       openWorldHint: false,
     },

--- a/src/tools/quickstarts.ts
+++ b/src/tools/quickstarts.ts
@@ -164,6 +164,7 @@ export const QUICKSTART_HANDLERS: Record<
       if (!envFilePath) {
         return createErrorResponse(
           `Error: No environment file found in "${resolvedProjectPath}". ` +
+            `Expected one of: .env.local, .env, .env.development.local, .env.development, or ${snippetFileName}. ` +
             'Please call auth0_save_credentials_to_file first to set up your environment file.'
         );
       }

--- a/src/tools/quickstarts.ts
+++ b/src/tools/quickstarts.ts
@@ -36,12 +36,12 @@ export const QUICKSTART_TOOLS: Tool[] = [
         framework: {
           type: 'string',
           enum: SUPPORTED_FRAMEWORKS,
-          description: 'JavaScript framework for the quickstart',
+          description: 'Supported framework for the quickstart',
         },
         project_path: {
           type: 'string',
           description:
-            'Path to the project directory. Used for .env file check and project config port detection.',
+            'Absolute path to the project directory. Used for .env file check and project config port detection.',
         },
         base_url: {
           type: 'string',
@@ -95,10 +95,10 @@ export const QUICKSTART_HANDLERS: Record<
     if (!projectPath) {
       return createErrorResponse('Error: project_path is required');
     }
-    const resolvedProjectPath = path.resolve(projectPath);
-    if (resolvedProjectPath !== projectPath && projectPath.includes('..')) {
-      return createErrorResponse('Error: project_path must not contain path traversal sequences');
+    if (!path.isAbsolute(projectPath)) {
+      return createErrorResponse('Error: project_path must be an absolute path');
     }
+    const resolvedProjectPath = path.resolve(projectPath);
     if (!fs.statSync(resolvedProjectPath, { throwIfNoEntry: false })?.isDirectory()) {
       return createErrorResponse('Error: project_path must be an existing directory');
     }

--- a/src/tools/quickstarts.ts
+++ b/src/tools/quickstarts.ts
@@ -7,6 +7,7 @@ import { fetchQuickstartSpec } from '../utils/quickstarts.js';
 import { resolveCallbackUrls } from '../utils/onboarding.js';
 import { fetchWithOptions } from '../utils/fetch.js';
 import { calculateUrlUpdates, resolvePlaceholders } from '../utils/quickstart-guide.js';
+import { detectExistingEnvFile } from '../utils/credentials-writer.js';
 import { APPLICATION_HANDLERS } from './applications.js';
 
 const VALID_FRAMEWORKS = ['react', 'vue', 'angular', 'nextjs'];
@@ -140,12 +141,26 @@ export const QUICKSTART_HANDLERS: Record<
       return createErrorResponse('Error: Failed to parse application data');
     }
 
-    // Step 3: Check .env file exists (only when spec has envSnippet)
+    // Step 3: Check .env file exists (only when spec has envSnippet).
+    // Credentials may have been saved to any pre-existing env file (e.g. .env.development),
+    // so detect an existing file before falling back to the spec's preferred filename.
+    let envFilePath: string | null = null;
     if (spec.envSnippet) {
-      const envFilePath = path.join(resolvedProjectPath, spec.envSnippet.fileName);
-      if (!fs.existsSync(envFilePath)) {
+      const snippetFileName = spec.envSnippet.fileName;
+      if (snippetFileName !== path.basename(snippetFileName)) {
         return createErrorResponse(
-          `Error: Environment file not found at "${envFilePath}". ` +
+          `Error: Quickstart spec for "${framework}" has an invalid env file name "${snippetFileName}". ` +
+            'The file name must not contain a path.'
+        );
+      }
+      envFilePath =
+        detectExistingEnvFile(resolvedProjectPath) ??
+        (fs.existsSync(path.join(resolvedProjectPath, snippetFileName))
+          ? path.join(resolvedProjectPath, snippetFileName)
+          : null);
+      if (!envFilePath) {
+        return createErrorResponse(
+          `Error: No environment file found in "${resolvedProjectPath}". ` +
             'Please call auth0_save_credentials_to_file first to set up your environment file.'
         );
       }
@@ -253,6 +268,11 @@ export const QUICKSTART_HANDLERS: Record<
     }
     actionsTaken.push(`Fetched quickstart guide for ${framework}`);
 
+    const credentialsNote = envFilePath
+      ? ` Auth0 credentials are already saved to "${envFilePath}". Use that file as-is and skip ` +
+        `any environment-variable or .env setup steps in the quickstart_prompt; do not create or copy a new .env file.`
+      : '';
+
     return createSuccessResponse({
       success: true,
       client_id: clientId,
@@ -264,12 +284,14 @@ export const QUICKSTART_HANDLERS: Record<
       urls_updated: updatePayload !== null,
       url_source: resolvedUrls.url_source,
       actions_taken: actionsTaken,
+      credentials_file: envFilePath,
       instructions:
         `First, summarize actions_taken to the user so they know what was configured on their Auth0 application. ` +
         `Then implement the code from quickstart_prompt in the user's project at project_path. ` +
         `If you have file-write capabilities, create and modify files directly. ` +
         `If you do not have file-write capabilities, present each code block to the user ` +
-        `with the file path where it should be created or modified.`,
+        `with the file path where it should be created or modified.${credentialsNote} ` +
+        `Once the integration code is in place, the onboarding is complete — let the user know.`,
     });
   },
 };

--- a/src/tools/quickstarts.ts
+++ b/src/tools/quickstarts.ts
@@ -211,8 +211,8 @@ export const QUICKSTART_HANDLERS: Record<
       port,
       appDomain: baseUrlParsed.hostname,
       appScheme: baseUrlParsed.protocol.replace(':', ''),
-      auth0ClientSecret: "*******MASKED*********",
-      sessionCookieSecret: "*******MASKED*********",
+      auth0ClientSecret: '*******MASKED*********',
+      sessionCookieSecret: '*******MASKED*********',
     };
 
     for (const [key, def] of Object.entries(spec.inputs)) {

--- a/src/utils/env-credentials.ts
+++ b/src/utils/env-credentials.ts
@@ -62,6 +62,13 @@ export async function resolveAndWriteCredentials(
 ): Promise<EnvCredentialsResult> {
   const { client_id: clientId, framework, project_path: projectPath } = params;
 
+  if (!path.isAbsolute(projectPath)) {
+    return {
+      success: false,
+      error: `project_path "${projectPath}" must be an absolute path`,
+    };
+  }
+
   if (!fs.existsSync(projectPath) || !fs.statSync(projectPath).isDirectory()) {
     return {
       success: false,

--- a/src/utils/quickstart-guide.ts
+++ b/src/utils/quickstart-guide.ts
@@ -1,0 +1,134 @@
+import { ResolvedCallbackUrls } from './onboarding.js';
+
+export interface UrlUpdatePayload {
+  callbacks?: string[];
+  allowed_logout_urls?: string[];
+  web_origins?: string[];
+  skip_non_verifiable_callback_uri_confirmation_prompt?: boolean;
+}
+
+export interface ConfiguredUrls {
+  callbacks: string[];
+  allowed_logout_urls: string[];
+  web_origins?: string[];
+  skip_non_verifiable_callback_uri_confirmation_prompt?: boolean;
+}
+
+export interface UrlUpdateResult {
+  updatePayload: UrlUpdatePayload | null;
+  finalUrls: ConfiguredUrls;
+}
+
+// TODO: Replace with hasNonVerifiableCallbacks from src/utils/onboarding.ts
+// when https://github.com/auth0/auth0-mcp-server/pull/162 is merged
+export function hasNonVerifiableCallbacks(urls: string[]): boolean {
+  return urls.some((url) => {
+    try {
+      const parsed = new URL(url);
+      if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return true;
+      const host = parsed.hostname.toLowerCase();
+      if (host === 'localhost' || host === '[::1]' || host === '::1') return true;
+      if (host === '0.0.0.0') return true;
+      if (/^127\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(host)) return true;
+      return false;
+    } catch {
+      return true;
+    }
+  });
+}
+
+export function resolvePlaceholders(
+  prompt: string,
+  placeholders: Record<string, unknown>,
+  inputValues: Record<string, string>,
+  environment: Record<string, string>
+): string {
+  let result = prompt;
+
+  for (const [placeholder, definition] of Object.entries(placeholders)) {
+    let resolved: string | undefined;
+
+    if (typeof definition === 'string') {
+      resolved = definition;
+    } else if (definition && typeof definition === 'object') {
+      const def = definition as Record<string, unknown>;
+
+      if (typeof def.inputKey === 'string') {
+        resolved = inputValues[def.inputKey];
+      } else if (typeof def.environmentKey === 'string') {
+        resolved = environment[def.environmentKey];
+      }
+
+      if (resolved !== undefined && (def.prefix || def.suffix)) {
+        const prefix = typeof def.prefix === 'string' ? def.prefix : '';
+        const suffix = typeof def.suffix === 'string' ? def.suffix : '';
+        resolved = `${prefix}${resolved}${suffix}`;
+      }
+    }
+
+    if (resolved !== undefined) {
+      result = result.split(placeholder).join(resolved);
+    }
+  }
+
+  return result;
+}
+
+export function calculateUrlUpdates(
+  resolvedUrls: ResolvedCallbackUrls,
+  currentApp: Record<string, any>
+): UrlUpdateResult {
+  const fieldMapping: Array<{
+    resolvedKey: keyof ResolvedCallbackUrls;
+    appKey: string;
+    payloadKey: keyof UrlUpdatePayload;
+  }> = [
+    { resolvedKey: 'callback_urls', appKey: 'callbacks', payloadKey: 'callbacks' },
+    {
+      resolvedKey: 'logout_urls',
+      appKey: 'allowed_logout_urls',
+      payloadKey: 'allowed_logout_urls',
+    },
+    { resolvedKey: 'web_origins', appKey: 'web_origins', payloadKey: 'web_origins' },
+  ];
+
+  const updatePayload: UrlUpdatePayload = {};
+  const finalUrls: ConfiguredUrls = {
+    callbacks: [],
+    allowed_logout_urls: [],
+  };
+  let hasUpdates = false;
+
+  for (const { resolvedKey, appKey, payloadKey } of fieldMapping) {
+    const resolved = resolvedUrls[resolvedKey] as string[] | undefined;
+    if (!resolved) continue;
+
+    const existing: string[] = currentApp[appKey] || [];
+    const missing = resolved.filter((url) => !existing.includes(url));
+
+    const merged = missing.length > 0 ? [...existing, ...missing] : existing;
+
+    if (payloadKey === 'callbacks') {
+      finalUrls.callbacks = merged;
+    } else if (payloadKey === 'allowed_logout_urls') {
+      finalUrls.allowed_logout_urls = merged;
+    } else if (payloadKey === 'web_origins') {
+      finalUrls.web_origins = merged;
+    }
+
+    if (missing.length > 0) {
+      hasUpdates = true;
+      (updatePayload as any)[payloadKey] = merged;
+    }
+  }
+
+  if (hasUpdates && hasNonVerifiableCallbacks(finalUrls.callbacks)) {
+    updatePayload.skip_non_verifiable_callback_uri_confirmation_prompt = true;
+    finalUrls.skip_non_verifiable_callback_uri_confirmation_prompt = true;
+  }
+
+  return {
+    updatePayload: hasUpdates ? updatePayload : null,
+    finalUrls,
+  };
+}

--- a/src/utils/quickstart-guide.ts
+++ b/src/utils/quickstart-guide.ts
@@ -1,4 +1,4 @@
-import { ResolvedCallbackUrls } from './onboarding.js';
+import { ResolvedCallbackUrls, hasNonVerifiableCallbacks } from './onboarding.js';
 
 export interface UrlUpdatePayload {
   callbacks?: string[];
@@ -17,24 +17,6 @@ export interface ConfiguredUrls {
 export interface UrlUpdateResult {
   updatePayload: UrlUpdatePayload | null;
   finalUrls: ConfiguredUrls;
-}
-
-// TODO: Replace with hasNonVerifiableCallbacks from src/utils/onboarding.ts
-// when https://github.com/auth0/auth0-mcp-server/pull/162 is merged
-export function hasNonVerifiableCallbacks(urls: string[]): boolean {
-  return urls.some((url) => {
-    try {
-      const parsed = new URL(url);
-      if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return true;
-      const host = parsed.hostname.toLowerCase();
-      if (host === 'localhost' || host === '[::1]' || host === '::1') return true;
-      if (host === '0.0.0.0') return true;
-      if (/^127\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(host)) return true;
-      return false;
-    } catch {
-      return true;
-    }
-  });
 }
 
 export function resolvePlaceholders(

--- a/src/utils/quickstarts.ts
+++ b/src/utils/quickstarts.ts
@@ -5,6 +5,7 @@ import { isFrameworkSupported, FRAMEWORK_FILENAMES, type SupportedFramework } fr
 
 const CDN_BASE = 'https://cdn.auth0.com/manhattan/quickstarts';
 const QUICKSTART_RELEASE_URL = `${CDN_BASE}/releases/production.json`;
+const LLM_PROMPT_PATH_PREFIX = 'assets/llm-prompts/';
 
 const CACHE_TTL_MS = 60 * 60 * 1000;
 const FETCH_OPTIONS = { retries: 1 };
@@ -42,18 +43,22 @@ const QuickstartSpecSchema = z.object({
   callbackPath: z.string().min(1),
   logoutPath: z.string().min(1),
   llmPromptPath: z.string().min(1).optional(),
-  envSnippet: z.object({
-    type: z.string(),
-    language: z.string(),
-    fileName: z.string().min(1),
-    entries: z.array(EnvEntrySchema),
-  }).optional(),
+  envSnippet: z
+    .object({
+      type: z.string(),
+      language: z.string(),
+      fileName: z.string().min(1),
+      entries: z.array(EnvEntrySchema),
+    })
+    .optional(),
   placeholders: z.record(z.string(), z.unknown()),
   inputs: z.record(z.string(), z.unknown()),
   environment: z.record(z.string(), z.string()),
 });
 
-export type QuickstartSpec = z.infer<typeof QuickstartSpecSchema>;
+export type QuickstartSpec = z.infer<typeof QuickstartSpecSchema> & {
+  llmPromptUrl?: string;
+};
 export type QuickstartAppType = QuickstartSpec['appType'];
 export type DefaultAppOrigin = QuickstartSpec['defaultAppOrigin'];
 
@@ -67,6 +72,17 @@ class QuickstartCDNNotFoundError extends Error {
   }
 }
 
+function resolveLlmPromptUrl(version: string, llmPromptPath: string): string {
+  const versionBase = `${CDN_BASE}/versions/${version}/`;
+  const resolvedUrl = new URL(llmPromptPath, versionBase).href;
+  const expectedPromptPrefix = `${versionBase}${LLM_PROMPT_PATH_PREFIX}`;
+
+  if (!resolvedUrl.startsWith(expectedPromptPrefix)) {
+    throw new Error('Invalid llmPromptPath: resolved URL escapes LLM prompt CDN prefix');
+  }
+
+  return resolvedUrl;
+}
 
 const fetchFromCDN = async (framework: string): Promise<QuickstartSpec> => {
   const quickstartReleaseResponse = await fetchWithOptions(QUICKSTART_RELEASE_URL, FETCH_OPTIONS);
@@ -94,7 +110,13 @@ const fetchFromCDN = async (framework: string): Promise<QuickstartSpec> => {
   }
 
   const raw = await definitionResponse.json();
-  return QuickstartSpecSchema.parse(raw);
+  const spec: QuickstartSpec = QuickstartSpecSchema.parse(raw);
+
+  if (spec.llmPromptPath) {
+    spec.llmPromptUrl = resolveLlmPromptUrl(version, spec.llmPromptPath);
+  }
+
+  return spec;
 };
 
 export const fetchQuickstartSpec = async (framework: string): Promise<QuickstartSpec | null> => {

--- a/src/utils/quickstarts.ts
+++ b/src/utils/quickstarts.ts
@@ -1,7 +1,11 @@
 import { z } from 'zod';
 import { log } from './logger.js';
 import { fetchWithOptions } from './fetch.js';
-import { isFrameworkSupported, FRAMEWORK_FILENAMES, type SupportedFramework } from './onboarding.js';
+import {
+  isFrameworkSupported,
+  FRAMEWORK_FILENAMES,
+  type SupportedFramework,
+} from './onboarding.js';
 
 const CDN_BASE = 'https://cdn.auth0.com/manhattan/quickstarts';
 const QUICKSTART_RELEASE_URL = `${CDN_BASE}/releases/production.json`;

--- a/test/exports.test.ts
+++ b/test/exports.test.ts
@@ -9,7 +9,10 @@ describe('exports', () => {
   });
 
   it('all other tools are not marked localOnly', () => {
-    const localOnlyToolNames = ['auth0_save_credentials_to_file', 'auth0_get_quickstart_guide'];
+    const localOnlyToolNames = [
+      'auth0_save_credentials_to_file',
+      'auth0_configure_and_get_quickstart_guide',
+    ];
     const localOnlyTools = TOOLS.filter(
       (t) => !localOnlyToolNames.includes(t.name) && t._meta?.localOnly
     );

--- a/test/exports.test.ts
+++ b/test/exports.test.ts
@@ -9,10 +9,7 @@ describe('exports', () => {
   });
 
   it('all other tools are not marked localOnly', () => {
-    const localOnlyToolNames = [
-      'auth0_save_credentials_to_file',
-      'auth0_configure_and_get_quickstart_guide',
-    ];
+    const localOnlyToolNames = ['auth0_save_credentials_to_file', 'auth0_get_quickstart_guide'];
     const localOnlyTools = TOOLS.filter(
       (t) => !localOnlyToolNames.includes(t.name) && t._meta?.localOnly
     );

--- a/test/exports.test.ts
+++ b/test/exports.test.ts
@@ -9,8 +9,9 @@ describe('exports', () => {
   });
 
   it('all other tools are not marked localOnly', () => {
+    const localOnlyToolNames = ['auth0_save_credentials_to_file', 'auth0_get_quickstart_guide'];
     const localOnlyTools = TOOLS.filter(
-      (t) => t.name !== 'auth0_save_credentials_to_file' && t._meta?.localOnly
+      (t) => !localOnlyToolNames.includes(t.name) && t._meta?.localOnly
     );
     expect(localOnlyTools).toHaveLength(0);
   });

--- a/test/tools/applications.test.ts
+++ b/test/tools/applications.test.ts
@@ -774,6 +774,20 @@ describe('Applications Tool Handlers', () => {
       expect(response.content[0].text).toContain('does not exist or is not a directory');
     });
 
+    it('should propagate absolute-path error for a relative project_path', async () => {
+      mockResolveAndWrite.mockResolvedValueOnce({
+        success: false,
+        error: 'project_path "myapp" must be an absolute path',
+      });
+
+      const response = await APPLICATION_HANDLERS.auth0_save_credentials_to_file(
+        { token, parameters: { client_id: 'some-id', framework: 'react', project_path: 'myapp' } },
+        { domain }
+      );
+      expect(response.isError).toBe(true);
+      expect(response.content[0].text).toContain('must be an absolute path');
+    });
+
     it('should return success with no keys written when quickstart spec has no envSnippet', async () => {
       mockResolveAndWrite.mockResolvedValueOnce({
         success: true,

--- a/test/tools/index.test.ts
+++ b/test/tools/index.test.ts
@@ -4,6 +4,7 @@ import { ACTION_TOOLS, ACTION_HANDLERS } from '../../src/tools/actions';
 import { APPLICATION_TOOLS, APPLICATION_HANDLERS } from '../../src/tools/applications';
 import { FORM_TOOLS, FORM_HANDLERS } from '../../src/tools/forms';
 import { LOG_TOOLS, LOG_HANDLERS } from '../../src/tools/logs';
+import { QUICKSTART_TOOLS, QUICKSTART_HANDLERS } from '../../src/tools/quickstarts';
 import { RESOURCE_SERVER_TOOLS, RESOURCE_SERVER_HANDLERS } from '../../src/tools/resource-servers';
 import {
   APPLICATION_GRANTS_HANDLERS,
@@ -20,7 +21,8 @@ describe('Tools Index', () => {
         FORM_TOOLS.length +
         LOG_TOOLS.length +
         RESOURCE_SERVER_TOOLS.length +
-        APPLICATION_GRANTS_TOOLS.length;
+        APPLICATION_GRANTS_TOOLS.length +
+        QUICKSTART_TOOLS.length;
 
       // Verify the combined TOOLS array has the correct length
       expect(TOOLS.length).toBe(expectedToolCount);
@@ -33,6 +35,7 @@ describe('Tools Index', () => {
         ...LOG_TOOLS,
         ...RESOURCE_SERVER_TOOLS,
         ...APPLICATION_GRANTS_TOOLS,
+        ...QUICKSTART_TOOLS,
       ];
 
       allIndividualTools.forEach((tool) => {
@@ -50,6 +53,7 @@ describe('Tools Index', () => {
       const applicationHandlerKeys = Object.keys(APPLICATION_HANDLERS);
       const formHandlerKeys = Object.keys(FORM_HANDLERS);
       const logHandlerKeys = Object.keys(LOG_HANDLERS);
+      const quickstartHandlerKeys = Object.keys(QUICKSTART_HANDLERS);
       const resourceServerHandlerKeys = Object.keys(RESOURCE_SERVER_HANDLERS);
       const applicationGrantsHandlerKey = Object.keys(APPLICATION_GRANTS_HANDLERS);
 
@@ -59,6 +63,7 @@ describe('Tools Index', () => {
         applicationHandlerKeys.length +
         formHandlerKeys.length +
         logHandlerKeys.length +
+        quickstartHandlerKeys.length +
         resourceServerHandlerKeys.length +
         applicationGrantsHandlerKey.length;
 
@@ -71,6 +76,7 @@ describe('Tools Index', () => {
         ...applicationHandlerKeys,
         ...formHandlerKeys,
         ...logHandlerKeys,
+        ...quickstartHandlerKeys,
         ...resourceServerHandlerKeys,
         ...applicationGrantsHandlerKey,
       ];

--- a/test/tools/quickstarts.test.ts
+++ b/test/tools/quickstarts.test.ts
@@ -1199,7 +1199,7 @@ describe('auth0_get_quickstart_guide', () => {
       );
       expect(response.isError).toBe(true);
       expect(response.content[0].text).toContain('Unsupported framework');
-      expect(response.content[0].text).toContain('react, angular, vue, nextjs');
+      expect(response.content[0].text).toContain('react, vue, angular, nextjs');
     });
 
     it('should accept mixed-case framework values', async () => {

--- a/test/tools/quickstarts.test.ts
+++ b/test/tools/quickstarts.test.ts
@@ -71,7 +71,7 @@ const mockAppData = {
   web_origins: ['https://example.com'],
 };
 
-describe('auth0_configure_and_get_quickstart_guide', () => {
+describe('auth0_get_quickstart_guide', () => {
   let QUICKSTART_HANDLERS: typeof import('../../src/tools/quickstarts').QUICKSTART_HANDLERS;
   let QUICKSTART_TOOLS: typeof import('../../src/tools/quickstarts').QUICKSTART_TOOLS;
 
@@ -121,9 +121,7 @@ describe('auth0_configure_and_get_quickstart_guide', () => {
 
   describe('tool metadata', () => {
     it('should mark the tool as non-read-only and non-destructive (URL updates are additive)', () => {
-      const tool = QUICKSTART_TOOLS.find(
-        (t) => t.name === 'auth0_configure_and_get_quickstart_guide'
-      );
+      const tool = QUICKSTART_TOOLS.find((t) => t.name === 'auth0_get_quickstart_guide');
       expect(tool?.annotations?.readOnlyHint).toBe(false);
       expect(tool?.annotations?.destructiveHint).toBe(false);
     });
@@ -131,7 +129,7 @@ describe('auth0_configure_and_get_quickstart_guide', () => {
 
   describe('parameter validation', () => {
     it('should return error when client_id is missing', async () => {
-      const response = await QUICKSTART_HANDLERS.auth0_configure_and_get_quickstart_guide(
+      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
         { token, parameters: { framework: 'react', project_path: '/tmp/project' } },
         config
       );
@@ -140,7 +138,7 @@ describe('auth0_configure_and_get_quickstart_guide', () => {
     });
 
     it('should return error when framework is missing', async () => {
-      const response = await QUICKSTART_HANDLERS.auth0_configure_and_get_quickstart_guide(
+      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
         { token, parameters: { client_id: 'test-client-id', project_path: '/tmp/project' } },
         config
       );
@@ -149,7 +147,7 @@ describe('auth0_configure_and_get_quickstart_guide', () => {
     });
 
     it('should return error when project_path is missing', async () => {
-      const response = await QUICKSTART_HANDLERS.auth0_configure_and_get_quickstart_guide(
+      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
         { token, parameters: { client_id: 'test-client-id', framework: 'react' } },
         config
       );
@@ -158,7 +156,7 @@ describe('auth0_configure_and_get_quickstart_guide', () => {
     });
 
     it('should return error when token is missing', async () => {
-      const response = await QUICKSTART_HANDLERS.auth0_configure_and_get_quickstart_guide(
+      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
         {
           token: '',
           parameters: {
@@ -174,7 +172,7 @@ describe('auth0_configure_and_get_quickstart_guide', () => {
     });
 
     it('should return error when domain is not configured', async () => {
-      const response = await QUICKSTART_HANDLERS.auth0_configure_and_get_quickstart_guide(
+      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
         {
           token,
           parameters: {
@@ -194,7 +192,7 @@ describe('auth0_configure_and_get_quickstart_guide', () => {
     it('should return error when spec is unavailable', async () => {
       mockFetchQuickstartSpec.mockResolvedValue(null);
 
-      const response = await QUICKSTART_HANDLERS.auth0_configure_and_get_quickstart_guide(
+      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
         {
           token,
           parameters: {
@@ -215,7 +213,7 @@ describe('auth0_configure_and_get_quickstart_guide', () => {
         makeMockSpec({ llmPromptPath: undefined, llmPromptUrl: undefined })
       );
 
-      const response = await QUICKSTART_HANDLERS.auth0_configure_and_get_quickstart_guide(
+      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
         {
           token,
           parameters: {
@@ -233,7 +231,7 @@ describe('auth0_configure_and_get_quickstart_guide', () => {
 
   describe('application validation', () => {
     it('should return error when application is not found', async () => {
-      const response = await QUICKSTART_HANDLERS.auth0_configure_and_get_quickstart_guide(
+      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
         {
           token,
           parameters: {
@@ -258,7 +256,7 @@ describe('auth0_configure_and_get_quickstart_guide', () => {
         })
       );
 
-      const response = await QUICKSTART_HANDLERS.auth0_configure_and_get_quickstart_guide(
+      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
         {
           token,
           parameters: {
@@ -278,7 +276,7 @@ describe('auth0_configure_and_get_quickstart_guide', () => {
     it('should return error when .env file is missing', async () => {
       mockExistsSync.mockReturnValue(false);
 
-      const response = await QUICKSTART_HANDLERS.auth0_configure_and_get_quickstart_guide(
+      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
         {
           token,
           parameters: {
@@ -302,7 +300,7 @@ describe('auth0_configure_and_get_quickstart_guide', () => {
         })
       );
 
-      const response = await QUICKSTART_HANDLERS.auth0_configure_and_get_quickstart_guide(
+      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
         {
           token,
           parameters: {
@@ -321,7 +319,7 @@ describe('auth0_configure_and_get_quickstart_guide', () => {
       mockFetchQuickstartSpec.mockResolvedValue(makeMockSpec({ envSnippet: undefined }));
       mockExistsSync.mockReturnValue(false);
 
-      const response = await QUICKSTART_HANDLERS.auth0_configure_and_get_quickstart_guide(
+      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
         {
           token,
           parameters: {
@@ -365,7 +363,7 @@ describe('auth0_configure_and_get_quickstart_guide', () => {
         })
       );
 
-      const response = await QUICKSTART_HANDLERS.auth0_configure_and_get_quickstart_guide(
+      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
         {
           token,
           parameters: {
@@ -394,7 +392,7 @@ describe('auth0_configure_and_get_quickstart_guide', () => {
         })
       );
 
-      const response = await QUICKSTART_HANDLERS.auth0_configure_and_get_quickstart_guide(
+      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
         {
           token,
           parameters: {
@@ -423,7 +421,7 @@ describe('auth0_configure_and_get_quickstart_guide', () => {
         })
       );
 
-      const response = await QUICKSTART_HANDLERS.auth0_configure_and_get_quickstart_guide(
+      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
         {
           token,
           parameters: {
@@ -456,7 +454,7 @@ describe('auth0_configure_and_get_quickstart_guide', () => {
         })
       );
 
-      const response = await QUICKSTART_HANDLERS.auth0_configure_and_get_quickstart_guide(
+      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
         {
           token,
           parameters: {
@@ -486,7 +484,7 @@ describe('auth0_configure_and_get_quickstart_guide', () => {
         })
       );
 
-      const response = await QUICKSTART_HANDLERS.auth0_configure_and_get_quickstart_guide(
+      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
         {
           token,
           parameters: {
@@ -523,7 +521,7 @@ describe('auth0_configure_and_get_quickstart_guide', () => {
         })
       );
 
-      const response = await QUICKSTART_HANDLERS.auth0_configure_and_get_quickstart_guide(
+      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
         {
           token,
           parameters: {
@@ -558,7 +556,7 @@ describe('auth0_configure_and_get_quickstart_guide', () => {
         })
       );
 
-      const response = await QUICKSTART_HANDLERS.auth0_configure_and_get_quickstart_guide(
+      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
         {
           token,
           parameters: {
@@ -589,7 +587,7 @@ describe('auth0_configure_and_get_quickstart_guide', () => {
         })
       );
 
-      const response = await QUICKSTART_HANDLERS.auth0_configure_and_get_quickstart_guide(
+      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
         {
           token,
           parameters: {
@@ -623,7 +621,7 @@ describe('auth0_configure_and_get_quickstart_guide', () => {
         })
       );
 
-      const response = await QUICKSTART_HANDLERS.auth0_configure_and_get_quickstart_guide(
+      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
         {
           token,
           parameters: {
@@ -667,7 +665,7 @@ describe('auth0_configure_and_get_quickstart_guide', () => {
         })
       );
 
-      const response = await QUICKSTART_HANDLERS.auth0_configure_and_get_quickstart_guide(
+      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
         {
           token,
           parameters: {
@@ -700,7 +698,7 @@ describe('auth0_configure_and_get_quickstart_guide', () => {
         })
       );
 
-      const response = await QUICKSTART_HANDLERS.auth0_configure_and_get_quickstart_guide(
+      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
         {
           token,
           parameters: {
@@ -731,7 +729,7 @@ describe('auth0_configure_and_get_quickstart_guide', () => {
         })
       );
 
-      const response = await QUICKSTART_HANDLERS.auth0_configure_and_get_quickstart_guide(
+      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
         {
           token,
           parameters: {
@@ -759,7 +757,7 @@ describe('auth0_configure_and_get_quickstart_guide', () => {
         })
       );
 
-      const response = await QUICKSTART_HANDLERS.auth0_configure_and_get_quickstart_guide(
+      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
         {
           token,
           parameters: {
@@ -787,7 +785,7 @@ describe('auth0_configure_and_get_quickstart_guide', () => {
         })
       );
 
-      const response = await QUICKSTART_HANDLERS.auth0_configure_and_get_quickstart_guide(
+      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
         {
           token,
           parameters: {
@@ -806,7 +804,7 @@ describe('auth0_configure_and_get_quickstart_guide', () => {
 
   describe('placeholder injection', () => {
     it('should inject domain and client_id placeholders', async () => {
-      const response = await QUICKSTART_HANDLERS.auth0_configure_and_get_quickstart_guide(
+      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
         {
           token,
           parameters: {
@@ -843,7 +841,7 @@ describe('auth0_configure_and_get_quickstart_guide', () => {
         })
       );
 
-      const response = await QUICKSTART_HANDLERS.auth0_configure_and_get_quickstart_guide(
+      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
         {
           token,
           parameters: {
@@ -863,7 +861,7 @@ describe('auth0_configure_and_get_quickstart_guide', () => {
 
   describe('success response', () => {
     it('should return complete success response with all fields', async () => {
-      const response = await QUICKSTART_HANDLERS.auth0_configure_and_get_quickstart_guide(
+      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
         {
           token,
           parameters: {
@@ -894,7 +892,7 @@ describe('auth0_configure_and_get_quickstart_guide', () => {
     });
 
     it('should return the normalized resolved path, not the raw input', async () => {
-      const response = await QUICKSTART_HANDLERS.auth0_configure_and_get_quickstart_guide(
+      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
         {
           token,
           parameters: {
@@ -911,7 +909,7 @@ describe('auth0_configure_and_get_quickstart_guide', () => {
     });
 
     it('should include web_origins for SPA apps', async () => {
-      const response = await QUICKSTART_HANDLERS.auth0_configure_and_get_quickstart_guide(
+      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
         {
           token,
           parameters: {
@@ -929,7 +927,7 @@ describe('auth0_configure_and_get_quickstart_guide', () => {
     it('should omit web_origins for webapp apps', async () => {
       mockFetchQuickstartSpec.mockResolvedValue(makeMockSpec({ appType: 'webapp' }));
 
-      const response = await QUICKSTART_HANDLERS.auth0_configure_and_get_quickstart_guide(
+      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
         {
           token,
           parameters: {
@@ -945,7 +943,7 @@ describe('auth0_configure_and_get_quickstart_guide', () => {
     });
 
     it('should set url_source to framework_default when no base_url provided', async () => {
-      const response = await QUICKSTART_HANDLERS.auth0_configure_and_get_quickstart_guide(
+      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
         {
           token,
           parameters: {
@@ -972,7 +970,7 @@ describe('auth0_configure_and_get_quickstart_guide', () => {
         })
       );
 
-      const response = await QUICKSTART_HANDLERS.auth0_configure_and_get_quickstart_guide(
+      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
         {
           token,
           parameters: {
@@ -1002,7 +1000,7 @@ describe('auth0_configure_and_get_quickstart_guide', () => {
         })
       );
 
-      const response = await QUICKSTART_HANDLERS.auth0_configure_and_get_quickstart_guide(
+      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
         {
           token,
           parameters: {
@@ -1040,7 +1038,7 @@ describe('auth0_configure_and_get_quickstart_guide', () => {
         })
       );
 
-      const response = await QUICKSTART_HANDLERS.auth0_configure_and_get_quickstart_guide(
+      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
         {
           token,
           parameters: {
@@ -1076,7 +1074,7 @@ describe('auth0_configure_and_get_quickstart_guide', () => {
         })
       );
 
-      const response = await QUICKSTART_HANDLERS.auth0_configure_and_get_quickstart_guide(
+      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
         {
           token,
           parameters: {
@@ -1106,7 +1104,7 @@ describe('auth0_configure_and_get_quickstart_guide', () => {
         })
       );
 
-      const response = await QUICKSTART_HANDLERS.auth0_configure_and_get_quickstart_guide(
+      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
         {
           token,
           parameters: {
@@ -1124,7 +1122,7 @@ describe('auth0_configure_and_get_quickstart_guide', () => {
 
   describe('absolute path enforcement', () => {
     it('should reject relative project_path', async () => {
-      const response = await QUICKSTART_HANDLERS.auth0_configure_and_get_quickstart_guide(
+      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
         {
           token,
           parameters: {
@@ -1140,7 +1138,7 @@ describe('auth0_configure_and_get_quickstart_guide', () => {
     });
 
     it('should reject a bare relative directory name', async () => {
-      const response = await QUICKSTART_HANDLERS.auth0_configure_and_get_quickstart_guide(
+      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
         {
           token,
           parameters: {
@@ -1160,7 +1158,7 @@ describe('auth0_configure_and_get_quickstart_guide', () => {
     it('should reject project_path that is not an existing directory', async () => {
       mockStatSync.mockReturnValue(null);
 
-      const response = await QUICKSTART_HANDLERS.auth0_configure_and_get_quickstart_guide(
+      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
         {
           token,
           parameters: {
@@ -1178,7 +1176,7 @@ describe('auth0_configure_and_get_quickstart_guide', () => {
     it('should reject project_path that is a file', async () => {
       mockStatSync.mockReturnValue({ isDirectory: () => false });
 
-      const response = await QUICKSTART_HANDLERS.auth0_configure_and_get_quickstart_guide(
+      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
         {
           token,
           parameters: {
@@ -1196,7 +1194,7 @@ describe('auth0_configure_and_get_quickstart_guide', () => {
     it('should reject project_path when statSync returns undefined (throwIfNoEntry: false)', async () => {
       mockStatSync.mockReturnValue(undefined);
 
-      const response = await QUICKSTART_HANDLERS.auth0_configure_and_get_quickstart_guide(
+      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
         {
           token,
           parameters: {
@@ -1214,7 +1212,7 @@ describe('auth0_configure_and_get_quickstart_guide', () => {
 
   describe('framework validation', () => {
     it('should reject unsupported framework values', async () => {
-      const response = await QUICKSTART_HANDLERS.auth0_configure_and_get_quickstart_guide(
+      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
         {
           token,
           parameters: {
@@ -1231,7 +1229,7 @@ describe('auth0_configure_and_get_quickstart_guide', () => {
     });
 
     it('should accept mixed-case framework values', async () => {
-      const response = await QUICKSTART_HANDLERS.auth0_configure_and_get_quickstart_guide(
+      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
         {
           token,
           parameters: {
@@ -1263,7 +1261,7 @@ describe('auth0_configure_and_get_quickstart_guide', () => {
         })
       );
 
-      const response = await QUICKSTART_HANDLERS.auth0_configure_and_get_quickstart_guide(
+      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
         {
           token,
           parameters: {
@@ -1296,7 +1294,7 @@ describe('auth0_configure_and_get_quickstart_guide', () => {
         })
       );
 
-      const response = await QUICKSTART_HANDLERS.auth0_configure_and_get_quickstart_guide(
+      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
         {
           token,
           parameters: {
@@ -1324,7 +1322,7 @@ describe('auth0_configure_and_get_quickstart_guide', () => {
         })
       );
 
-      const response = await QUICKSTART_HANDLERS.auth0_configure_and_get_quickstart_guide(
+      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
         {
           token,
           parameters: {
@@ -1357,7 +1355,7 @@ describe('auth0_configure_and_get_quickstart_guide', () => {
         })
       );
 
-      const response = await QUICKSTART_HANDLERS.auth0_configure_and_get_quickstart_guide(
+      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
         {
           token,
           parameters: {

--- a/test/tools/quickstarts.test.ts
+++ b/test/tools/quickstarts.test.ts
@@ -289,6 +289,7 @@ describe('auth0_get_quickstart_guide', () => {
       );
       expect(response.isError).toBe(true);
       expect(response.content[0].text).toContain('No environment file found');
+      expect(response.content[0].text).toContain('Expected one of: .env.local, .env');
       expect(response.content[0].text).toContain('auth0_save_credentials_to_file');
     });
 

--- a/test/tools/quickstarts.test.ts
+++ b/test/tools/quickstarts.test.ts
@@ -1094,8 +1094,8 @@ describe('auth0_get_quickstart_guide', () => {
     });
   });
 
-  describe('path traversal protection', () => {
-    it('should reject project_path containing traversal sequences', async () => {
+  describe('absolute path enforcement', () => {
+    it('should reject relative project_path', async () => {
       const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
         {
           token,
@@ -1108,23 +1108,23 @@ describe('auth0_get_quickstart_guide', () => {
         config
       );
       expect(response.isError).toBe(true);
-      expect(response.content[0].text).toContain('path traversal');
+      expect(response.content[0].text).toContain('must be an absolute path');
     });
 
-    it('should reject deeply nested traversal', async () => {
+    it('should reject a bare relative directory name', async () => {
       const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
         {
           token,
           parameters: {
             client_id: 'test-client-id',
             framework: 'react',
-            project_path: '/tmp/project/../../../etc/passwd',
+            project_path: 'myapp',
           },
         },
         config
       );
       expect(response.isError).toBe(true);
-      expect(response.content[0].text).toContain('path traversal');
+      expect(response.content[0].text).toContain('must be an absolute path');
     });
   });
 

--- a/test/tools/quickstarts.test.ts
+++ b/test/tools/quickstarts.test.ts
@@ -288,8 +288,30 @@ describe('auth0_get_quickstart_guide', () => {
         config
       );
       expect(response.isError).toBe(true);
-      expect(response.content[0].text).toContain('Environment file not found');
+      expect(response.content[0].text).toContain('No environment file found');
       expect(response.content[0].text).toContain('auth0_save_credentials_to_file');
+    });
+
+    it('should reject a spec whose envSnippet.fileName contains a path', async () => {
+      mockFetchQuickstartSpec.mockResolvedValue(
+        makeMockSpec({
+          envSnippet: { ...makeMockSpec().envSnippet, fileName: '../../escape.env' },
+        })
+      );
+
+      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
+        {
+          token,
+          parameters: {
+            client_id: 'test-client-id',
+            framework: 'react',
+            project_path: '/tmp/project',
+          },
+        },
+        config
+      );
+      expect(response.isError).toBe(true);
+      expect(response.content[0].text).toContain('invalid env file name');
     });
 
     it('should skip .env check when spec has no envSnippet', async () => {

--- a/test/tools/quickstarts.test.ts
+++ b/test/tools/quickstarts.test.ts
@@ -1199,10 +1199,10 @@ describe('auth0_get_quickstart_guide', () => {
       );
       expect(response.isError).toBe(true);
       expect(response.content[0].text).toContain('Unsupported framework');
-      expect(response.content[0].text).toContain('react, vue, angular, nextjs');
+      expect(response.content[0].text).toContain('react, angular, vue, nextjs');
     });
 
-    it('should reject mixed-case framework values', async () => {
+    it('should accept mixed-case framework values', async () => {
       const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
         {
           token,
@@ -1214,9 +1214,7 @@ describe('auth0_get_quickstart_guide', () => {
         },
         config
       );
-      expect(response.isError).toBe(true);
-      expect(response.content[0].text).toContain('Unsupported framework');
-      expect(response.content[0].text).toContain('React');
+      expect(response.isError).toBeFalsy();
     });
   });
 

--- a/test/tools/quickstarts.test.ts
+++ b/test/tools/quickstarts.test.ts
@@ -120,10 +120,10 @@ describe('auth0_get_quickstart_guide', () => {
   });
 
   describe('tool metadata', () => {
-    it('should mark the tool as destructive because it updates application URLs', () => {
+    it('should mark the tool as non-read-only and non-destructive (URL updates are additive)', () => {
       const tool = QUICKSTART_TOOLS.find((t) => t.name === 'auth0_get_quickstart_guide');
       expect(tool?.annotations?.readOnlyHint).toBe(false);
-      expect(tool?.annotations?.destructiveHint).toBe(true);
+      expect(tool?.annotations?.destructiveHint).toBe(false);
     });
   });
 

--- a/test/tools/quickstarts.test.ts
+++ b/test/tools/quickstarts.test.ts
@@ -1015,6 +1015,9 @@ describe('auth0_get_quickstart_guide', () => {
       expect(result.configured_urls.skip_non_verifiable_callback_uri_confirmation_prompt).toBe(
         true
       );
+      expect(result.actions_taken).toContain(
+        'Enabled skip_non_verifiable_callback_uri_confirmation_prompt because a non-verifiable (custom scheme or localhost) callback URL was configured'
+      );
     });
 
     it('should not include skip flag when only HTTPS production URLs exist', async () => {
@@ -1050,6 +1053,11 @@ describe('auth0_get_quickstart_guide', () => {
       expect(
         result.configured_urls.skip_non_verifiable_callback_uri_confirmation_prompt
       ).toBeUndefined();
+      expect(
+        result.actions_taken.some((a: string) =>
+          a.includes('skip_non_verifiable_callback_uri_confirmation_prompt')
+        )
+      ).toBe(false);
     });
   });
 

--- a/test/tools/quickstarts.test.ts
+++ b/test/tools/quickstarts.test.ts
@@ -71,7 +71,7 @@ const mockAppData = {
   web_origins: ['https://example.com'],
 };
 
-describe('auth0_get_quickstart_guide', () => {
+describe('auth0_configure_and_get_quickstart_guide', () => {
   let QUICKSTART_HANDLERS: typeof import('../../src/tools/quickstarts').QUICKSTART_HANDLERS;
   let QUICKSTART_TOOLS: typeof import('../../src/tools/quickstarts').QUICKSTART_TOOLS;
 
@@ -121,7 +121,9 @@ describe('auth0_get_quickstart_guide', () => {
 
   describe('tool metadata', () => {
     it('should mark the tool as non-read-only and non-destructive (URL updates are additive)', () => {
-      const tool = QUICKSTART_TOOLS.find((t) => t.name === 'auth0_get_quickstart_guide');
+      const tool = QUICKSTART_TOOLS.find(
+        (t) => t.name === 'auth0_configure_and_get_quickstart_guide'
+      );
       expect(tool?.annotations?.readOnlyHint).toBe(false);
       expect(tool?.annotations?.destructiveHint).toBe(false);
     });
@@ -129,7 +131,7 @@ describe('auth0_get_quickstart_guide', () => {
 
   describe('parameter validation', () => {
     it('should return error when client_id is missing', async () => {
-      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
+      const response = await QUICKSTART_HANDLERS.auth0_configure_and_get_quickstart_guide(
         { token, parameters: { framework: 'react', project_path: '/tmp/project' } },
         config
       );
@@ -138,7 +140,7 @@ describe('auth0_get_quickstart_guide', () => {
     });
 
     it('should return error when framework is missing', async () => {
-      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
+      const response = await QUICKSTART_HANDLERS.auth0_configure_and_get_quickstart_guide(
         { token, parameters: { client_id: 'test-client-id', project_path: '/tmp/project' } },
         config
       );
@@ -147,7 +149,7 @@ describe('auth0_get_quickstart_guide', () => {
     });
 
     it('should return error when project_path is missing', async () => {
-      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
+      const response = await QUICKSTART_HANDLERS.auth0_configure_and_get_quickstart_guide(
         { token, parameters: { client_id: 'test-client-id', framework: 'react' } },
         config
       );
@@ -156,7 +158,7 @@ describe('auth0_get_quickstart_guide', () => {
     });
 
     it('should return error when token is missing', async () => {
-      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
+      const response = await QUICKSTART_HANDLERS.auth0_configure_and_get_quickstart_guide(
         {
           token: '',
           parameters: {
@@ -172,7 +174,7 @@ describe('auth0_get_quickstart_guide', () => {
     });
 
     it('should return error when domain is not configured', async () => {
-      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
+      const response = await QUICKSTART_HANDLERS.auth0_configure_and_get_quickstart_guide(
         {
           token,
           parameters: {
@@ -192,7 +194,7 @@ describe('auth0_get_quickstart_guide', () => {
     it('should return error when spec is unavailable', async () => {
       mockFetchQuickstartSpec.mockResolvedValue(null);
 
-      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
+      const response = await QUICKSTART_HANDLERS.auth0_configure_and_get_quickstart_guide(
         {
           token,
           parameters: {
@@ -213,7 +215,7 @@ describe('auth0_get_quickstart_guide', () => {
         makeMockSpec({ llmPromptPath: undefined, llmPromptUrl: undefined })
       );
 
-      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
+      const response = await QUICKSTART_HANDLERS.auth0_configure_and_get_quickstart_guide(
         {
           token,
           parameters: {
@@ -231,7 +233,7 @@ describe('auth0_get_quickstart_guide', () => {
 
   describe('application validation', () => {
     it('should return error when application is not found', async () => {
-      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
+      const response = await QUICKSTART_HANDLERS.auth0_configure_and_get_quickstart_guide(
         {
           token,
           parameters: {
@@ -256,7 +258,7 @@ describe('auth0_get_quickstart_guide', () => {
         })
       );
 
-      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
+      const response = await QUICKSTART_HANDLERS.auth0_configure_and_get_quickstart_guide(
         {
           token,
           parameters: {
@@ -276,7 +278,7 @@ describe('auth0_get_quickstart_guide', () => {
     it('should return error when .env file is missing', async () => {
       mockExistsSync.mockReturnValue(false);
 
-      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
+      const response = await QUICKSTART_HANDLERS.auth0_configure_and_get_quickstart_guide(
         {
           token,
           parameters: {
@@ -300,7 +302,7 @@ describe('auth0_get_quickstart_guide', () => {
         })
       );
 
-      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
+      const response = await QUICKSTART_HANDLERS.auth0_configure_and_get_quickstart_guide(
         {
           token,
           parameters: {
@@ -319,7 +321,7 @@ describe('auth0_get_quickstart_guide', () => {
       mockFetchQuickstartSpec.mockResolvedValue(makeMockSpec({ envSnippet: undefined }));
       mockExistsSync.mockReturnValue(false);
 
-      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
+      const response = await QUICKSTART_HANDLERS.auth0_configure_and_get_quickstart_guide(
         {
           token,
           parameters: {
@@ -363,7 +365,7 @@ describe('auth0_get_quickstart_guide', () => {
         })
       );
 
-      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
+      const response = await QUICKSTART_HANDLERS.auth0_configure_and_get_quickstart_guide(
         {
           token,
           parameters: {
@@ -392,7 +394,7 @@ describe('auth0_get_quickstart_guide', () => {
         })
       );
 
-      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
+      const response = await QUICKSTART_HANDLERS.auth0_configure_and_get_quickstart_guide(
         {
           token,
           parameters: {
@@ -421,7 +423,7 @@ describe('auth0_get_quickstart_guide', () => {
         })
       );
 
-      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
+      const response = await QUICKSTART_HANDLERS.auth0_configure_and_get_quickstart_guide(
         {
           token,
           parameters: {
@@ -454,7 +456,7 @@ describe('auth0_get_quickstart_guide', () => {
         })
       );
 
-      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
+      const response = await QUICKSTART_HANDLERS.auth0_configure_and_get_quickstart_guide(
         {
           token,
           parameters: {
@@ -484,7 +486,7 @@ describe('auth0_get_quickstart_guide', () => {
         })
       );
 
-      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
+      const response = await QUICKSTART_HANDLERS.auth0_configure_and_get_quickstart_guide(
         {
           token,
           parameters: {
@@ -521,7 +523,7 @@ describe('auth0_get_quickstart_guide', () => {
         })
       );
 
-      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
+      const response = await QUICKSTART_HANDLERS.auth0_configure_and_get_quickstart_guide(
         {
           token,
           parameters: {
@@ -556,7 +558,7 @@ describe('auth0_get_quickstart_guide', () => {
         })
       );
 
-      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
+      const response = await QUICKSTART_HANDLERS.auth0_configure_and_get_quickstart_guide(
         {
           token,
           parameters: {
@@ -587,7 +589,7 @@ describe('auth0_get_quickstart_guide', () => {
         })
       );
 
-      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
+      const response = await QUICKSTART_HANDLERS.auth0_configure_and_get_quickstart_guide(
         {
           token,
           parameters: {
@@ -621,7 +623,7 @@ describe('auth0_get_quickstart_guide', () => {
         })
       );
 
-      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
+      const response = await QUICKSTART_HANDLERS.auth0_configure_and_get_quickstart_guide(
         {
           token,
           parameters: {
@@ -665,7 +667,7 @@ describe('auth0_get_quickstart_guide', () => {
         })
       );
 
-      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
+      const response = await QUICKSTART_HANDLERS.auth0_configure_and_get_quickstart_guide(
         {
           token,
           parameters: {
@@ -698,7 +700,7 @@ describe('auth0_get_quickstart_guide', () => {
         })
       );
 
-      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
+      const response = await QUICKSTART_HANDLERS.auth0_configure_and_get_quickstart_guide(
         {
           token,
           parameters: {
@@ -729,7 +731,7 @@ describe('auth0_get_quickstart_guide', () => {
         })
       );
 
-      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
+      const response = await QUICKSTART_HANDLERS.auth0_configure_and_get_quickstart_guide(
         {
           token,
           parameters: {
@@ -757,7 +759,7 @@ describe('auth0_get_quickstart_guide', () => {
         })
       );
 
-      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
+      const response = await QUICKSTART_HANDLERS.auth0_configure_and_get_quickstart_guide(
         {
           token,
           parameters: {
@@ -785,7 +787,7 @@ describe('auth0_get_quickstart_guide', () => {
         })
       );
 
-      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
+      const response = await QUICKSTART_HANDLERS.auth0_configure_and_get_quickstart_guide(
         {
           token,
           parameters: {
@@ -804,7 +806,7 @@ describe('auth0_get_quickstart_guide', () => {
 
   describe('placeholder injection', () => {
     it('should inject domain and client_id placeholders', async () => {
-      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
+      const response = await QUICKSTART_HANDLERS.auth0_configure_and_get_quickstart_guide(
         {
           token,
           parameters: {
@@ -841,7 +843,7 @@ describe('auth0_get_quickstart_guide', () => {
         })
       );
 
-      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
+      const response = await QUICKSTART_HANDLERS.auth0_configure_and_get_quickstart_guide(
         {
           token,
           parameters: {
@@ -861,7 +863,7 @@ describe('auth0_get_quickstart_guide', () => {
 
   describe('success response', () => {
     it('should return complete success response with all fields', async () => {
-      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
+      const response = await QUICKSTART_HANDLERS.auth0_configure_and_get_quickstart_guide(
         {
           token,
           parameters: {
@@ -892,7 +894,7 @@ describe('auth0_get_quickstart_guide', () => {
     });
 
     it('should return the normalized resolved path, not the raw input', async () => {
-      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
+      const response = await QUICKSTART_HANDLERS.auth0_configure_and_get_quickstart_guide(
         {
           token,
           parameters: {
@@ -909,7 +911,7 @@ describe('auth0_get_quickstart_guide', () => {
     });
 
     it('should include web_origins for SPA apps', async () => {
-      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
+      const response = await QUICKSTART_HANDLERS.auth0_configure_and_get_quickstart_guide(
         {
           token,
           parameters: {
@@ -927,7 +929,7 @@ describe('auth0_get_quickstart_guide', () => {
     it('should omit web_origins for webapp apps', async () => {
       mockFetchQuickstartSpec.mockResolvedValue(makeMockSpec({ appType: 'webapp' }));
 
-      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
+      const response = await QUICKSTART_HANDLERS.auth0_configure_and_get_quickstart_guide(
         {
           token,
           parameters: {
@@ -943,7 +945,7 @@ describe('auth0_get_quickstart_guide', () => {
     });
 
     it('should set url_source to framework_default when no base_url provided', async () => {
-      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
+      const response = await QUICKSTART_HANDLERS.auth0_configure_and_get_quickstart_guide(
         {
           token,
           parameters: {
@@ -970,7 +972,7 @@ describe('auth0_get_quickstart_guide', () => {
         })
       );
 
-      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
+      const response = await QUICKSTART_HANDLERS.auth0_configure_and_get_quickstart_guide(
         {
           token,
           parameters: {
@@ -1000,7 +1002,7 @@ describe('auth0_get_quickstart_guide', () => {
         })
       );
 
-      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
+      const response = await QUICKSTART_HANDLERS.auth0_configure_and_get_quickstart_guide(
         {
           token,
           parameters: {
@@ -1038,7 +1040,7 @@ describe('auth0_get_quickstart_guide', () => {
         })
       );
 
-      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
+      const response = await QUICKSTART_HANDLERS.auth0_configure_and_get_quickstart_guide(
         {
           token,
           parameters: {
@@ -1074,7 +1076,7 @@ describe('auth0_get_quickstart_guide', () => {
         })
       );
 
-      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
+      const response = await QUICKSTART_HANDLERS.auth0_configure_and_get_quickstart_guide(
         {
           token,
           parameters: {
@@ -1104,7 +1106,7 @@ describe('auth0_get_quickstart_guide', () => {
         })
       );
 
-      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
+      const response = await QUICKSTART_HANDLERS.auth0_configure_and_get_quickstart_guide(
         {
           token,
           parameters: {
@@ -1122,7 +1124,7 @@ describe('auth0_get_quickstart_guide', () => {
 
   describe('absolute path enforcement', () => {
     it('should reject relative project_path', async () => {
-      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
+      const response = await QUICKSTART_HANDLERS.auth0_configure_and_get_quickstart_guide(
         {
           token,
           parameters: {
@@ -1138,7 +1140,7 @@ describe('auth0_get_quickstart_guide', () => {
     });
 
     it('should reject a bare relative directory name', async () => {
-      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
+      const response = await QUICKSTART_HANDLERS.auth0_configure_and_get_quickstart_guide(
         {
           token,
           parameters: {
@@ -1158,7 +1160,7 @@ describe('auth0_get_quickstart_guide', () => {
     it('should reject project_path that is not an existing directory', async () => {
       mockStatSync.mockReturnValue(null);
 
-      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
+      const response = await QUICKSTART_HANDLERS.auth0_configure_and_get_quickstart_guide(
         {
           token,
           parameters: {
@@ -1176,7 +1178,7 @@ describe('auth0_get_quickstart_guide', () => {
     it('should reject project_path that is a file', async () => {
       mockStatSync.mockReturnValue({ isDirectory: () => false });
 
-      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
+      const response = await QUICKSTART_HANDLERS.auth0_configure_and_get_quickstart_guide(
         {
           token,
           parameters: {
@@ -1194,7 +1196,7 @@ describe('auth0_get_quickstart_guide', () => {
     it('should reject project_path when statSync returns undefined (throwIfNoEntry: false)', async () => {
       mockStatSync.mockReturnValue(undefined);
 
-      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
+      const response = await QUICKSTART_HANDLERS.auth0_configure_and_get_quickstart_guide(
         {
           token,
           parameters: {
@@ -1212,7 +1214,7 @@ describe('auth0_get_quickstart_guide', () => {
 
   describe('framework validation', () => {
     it('should reject unsupported framework values', async () => {
-      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
+      const response = await QUICKSTART_HANDLERS.auth0_configure_and_get_quickstart_guide(
         {
           token,
           parameters: {
@@ -1229,7 +1231,7 @@ describe('auth0_get_quickstart_guide', () => {
     });
 
     it('should accept mixed-case framework values', async () => {
-      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
+      const response = await QUICKSTART_HANDLERS.auth0_configure_and_get_quickstart_guide(
         {
           token,
           parameters: {
@@ -1261,7 +1263,7 @@ describe('auth0_get_quickstart_guide', () => {
         })
       );
 
-      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
+      const response = await QUICKSTART_HANDLERS.auth0_configure_and_get_quickstart_guide(
         {
           token,
           parameters: {
@@ -1294,7 +1296,7 @@ describe('auth0_get_quickstart_guide', () => {
         })
       );
 
-      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
+      const response = await QUICKSTART_HANDLERS.auth0_configure_and_get_quickstart_guide(
         {
           token,
           parameters: {
@@ -1322,7 +1324,7 @@ describe('auth0_get_quickstart_guide', () => {
         })
       );
 
-      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
+      const response = await QUICKSTART_HANDLERS.auth0_configure_and_get_quickstart_guide(
         {
           token,
           parameters: {
@@ -1355,7 +1357,7 @@ describe('auth0_get_quickstart_guide', () => {
         })
       );
 
-      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
+      const response = await QUICKSTART_HANDLERS.auth0_configure_and_get_quickstart_guide(
         {
           token,
           parameters: {

--- a/test/tools/quickstarts.test.ts
+++ b/test/tools/quickstarts.test.ts
@@ -1,0 +1,1329 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { server } from '../setup';
+import { mockConfig } from '../mocks/config';
+
+vi.mock('../../src/utils/logger', () => ({
+  log: vi.fn(),
+}));
+
+const mockFetchQuickstartSpec = vi.fn();
+vi.mock('../../src/utils/quickstarts', () => ({
+  fetchQuickstartSpec: (...args: any[]) => mockFetchQuickstartSpec(...args),
+}));
+
+const mockExistsSync = vi.fn();
+const mockStatSync = vi.fn();
+vi.mock('fs', () => ({
+  existsSync: (...args: any[]) => mockExistsSync(...args),
+  statSync: (...args: any[]) => mockStatSync(...args),
+}));
+
+const MOCK_LLM_PROMPT_URL =
+  'https://cdn.auth0.com/manhattan/quickstarts/versions/1.0.0/assets/prompts/en/react-prompt.md';
+const MOCK_LLM_PROMPT =
+  'Install the SDK.\nDomain: %AUTH0_DOMAIN%\nClient ID: %AUTH0_CLIENT_ID%\nPort: %PORT%';
+
+const makeMockSpec = (overrides: Record<string, any> = {}) => ({
+  appType: 'spa',
+  defaultAppOrigin: { scheme: 'http', domain: 'localhost', port: 3000 },
+  callbackPath: '/callback',
+  logoutPath: '/',
+  llmPromptPath: 'assets/llm-prompts/react-llm-prompt.md',
+  llmPromptUrl: MOCK_LLM_PROMPT_URL,
+  envSnippet: {
+    type: 'env',
+    language: 'shell',
+    fileName: '.env',
+    entries: [
+      { type: 'var', name: 'VITE_AUTH0_DOMAIN', value: '{yourDomain}' },
+      { type: 'var', name: 'VITE_AUTH0_CLIENT_ID', value: '{yourClientId}' },
+    ],
+  },
+  placeholders: {
+    '%AUTH0_DOMAIN%': { inputKey: 'auth0Domain' },
+    '%AUTH0_CLIENT_ID%': { inputKey: 'auth0ClientId' },
+    '%PORT%': { inputKey: 'port' },
+    '%APP_DOMAIN%': { inputKey: 'appDomain' },
+    '%APP_SCHEME%': { inputKey: 'appScheme' },
+    '%SDK_VERSION%': '2.x',
+  },
+  inputs: {
+    auth0Domain: null,
+    auth0ClientId: null,
+    port: { default: 3000 },
+    appDomain: { default: 'localhost' },
+    appScheme: { default: 'http' },
+  },
+  environment: {
+    gitBranch: 'quickstart/login',
+    gitRemote: 'https://github.com/auth0-samples/auth0-react-samples',
+  },
+  ...overrides,
+});
+
+const mockAppData = {
+  client_id: 'test-client-id',
+  name: 'Test App',
+  app_type: 'spa',
+  callbacks: ['https://example.com/callback'],
+  allowed_logout_urls: ['https://example.com'],
+  web_origins: ['https://example.com'],
+};
+
+describe('auth0_get_quickstart_guide', () => {
+  let QUICKSTART_HANDLERS: typeof import('../../src/tools/quickstarts').QUICKSTART_HANDLERS;
+  let QUICKSTART_TOOLS: typeof import('../../src/tools/quickstarts').QUICKSTART_TOOLS;
+
+  const domain = mockConfig.domain;
+  const token = mockConfig.token;
+  const config = { domain };
+
+  beforeEach(async () => {
+    vi.resetAllMocks();
+    mockFetchQuickstartSpec.mockResolvedValue(makeMockSpec());
+    mockExistsSync.mockReturnValue(true);
+    mockStatSync.mockReturnValue({ isDirectory: () => true });
+
+    // MSW handler for the LLM prompt CDN
+    server.use(
+      http.get(MOCK_LLM_PROMPT_URL, () => {
+        return new HttpResponse(MOCK_LLM_PROMPT, { status: 200 });
+      })
+    );
+
+    // MSW handler for the application GET (returns full app data)
+    server.use(
+      http.get('https://*/api/v2/clients/:clientId', ({ params }) => {
+        if (params.clientId === 'test-client-id') {
+          return HttpResponse.json(mockAppData);
+        }
+        return new HttpResponse(null, { status: 404 });
+      })
+    );
+
+    // MSW handler for the application PATCH
+    server.use(
+      http.patch('https://*/api/v2/clients/:clientId', async ({ params, request }) => {
+        const updates = (await request.json()) as Record<string, any>;
+        return HttpResponse.json({ ...mockAppData, ...updates });
+      })
+    );
+
+    const mod = await import('../../src/tools/quickstarts');
+    QUICKSTART_HANDLERS = mod.QUICKSTART_HANDLERS;
+    QUICKSTART_TOOLS = mod.QUICKSTART_TOOLS;
+  });
+
+  afterEach(() => {
+    server.resetHandlers();
+  });
+
+  describe('tool metadata', () => {
+    it('should mark the tool as destructive because it updates application URLs', () => {
+      const tool = QUICKSTART_TOOLS.find((t) => t.name === 'auth0_get_quickstart_guide');
+      expect(tool?.annotations?.readOnlyHint).toBe(false);
+      expect(tool?.annotations?.destructiveHint).toBe(true);
+    });
+  });
+
+  describe('parameter validation', () => {
+    it('should return error when client_id is missing', async () => {
+      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
+        { token, parameters: { framework: 'react', project_path: '/tmp/project' } },
+        config
+      );
+      expect(response.isError).toBe(true);
+      expect(response.content[0].text).toContain('client_id is required');
+    });
+
+    it('should return error when framework is missing', async () => {
+      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
+        { token, parameters: { client_id: 'test-client-id', project_path: '/tmp/project' } },
+        config
+      );
+      expect(response.isError).toBe(true);
+      expect(response.content[0].text).toContain('framework is required');
+    });
+
+    it('should return error when project_path is missing', async () => {
+      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
+        { token, parameters: { client_id: 'test-client-id', framework: 'react' } },
+        config
+      );
+      expect(response.isError).toBe(true);
+      expect(response.content[0].text).toContain('project_path is required');
+    });
+
+    it('should return error when token is missing', async () => {
+      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
+        {
+          token: '',
+          parameters: {
+            client_id: 'test-client-id',
+            framework: 'react',
+            project_path: '/tmp/project',
+          },
+        },
+        config
+      );
+      expect(response.isError).toBe(true);
+      expect(response.content[0].text).toContain('Missing authorization token');
+    });
+
+    it('should return error when domain is not configured', async () => {
+      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
+        {
+          token,
+          parameters: {
+            client_id: 'test-client-id',
+            framework: 'react',
+            project_path: '/tmp/project',
+          },
+        },
+        { domain: undefined }
+      );
+      expect(response.isError).toBe(true);
+      expect(response.content[0].text).toContain('Auth0 domain is not configured');
+    });
+  });
+
+  describe('quickstart spec resolution', () => {
+    it('should return error when spec is unavailable', async () => {
+      mockFetchQuickstartSpec.mockResolvedValue(null);
+
+      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
+        {
+          token,
+          parameters: {
+            client_id: 'test-client-id',
+            framework: 'react',
+            project_path: '/tmp/project',
+          },
+        },
+        config
+      );
+      expect(response.isError).toBe(true);
+      expect(response.content[0].text).toContain('definition unavailable');
+      expect(response.content[0].text).toContain('react');
+    });
+
+    it('should return error when spec has no llmPromptUrl', async () => {
+      mockFetchQuickstartSpec.mockResolvedValue(
+        makeMockSpec({ llmPromptPath: undefined, llmPromptUrl: undefined })
+      );
+
+      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
+        {
+          token,
+          parameters: {
+            client_id: 'test-client-id',
+            framework: 'react',
+            project_path: '/tmp/project',
+          },
+        },
+        config
+      );
+      expect(response.isError).toBe(true);
+      expect(response.content[0].text).toContain('does not include an LLM prompt URL');
+    });
+  });
+
+  describe('application validation', () => {
+    it('should return error when application is not found', async () => {
+      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
+        {
+          token,
+          parameters: {
+            client_id: 'nonexistent-id',
+            framework: 'react',
+            project_path: '/tmp/project',
+          },
+        },
+        config
+      );
+      expect(response.isError).toBe(true);
+      expect(response.content[0].text).toContain('not found');
+    });
+
+    it('should return error when application data cannot be parsed as JSON', async () => {
+      server.use(
+        http.get('https://*/api/v2/clients/:clientId', () => {
+          return new HttpResponse('this is not json', {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          });
+        })
+      );
+
+      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
+        {
+          token,
+          parameters: {
+            client_id: 'test-client-id',
+            framework: 'react',
+            project_path: '/tmp/project',
+          },
+        },
+        config
+      );
+      expect(response.isError).toBe(true);
+      expect(response.content[0].text).toContain('is not valid JSON');
+    });
+  });
+
+  describe('environment file check', () => {
+    it('should return error when .env file is missing', async () => {
+      mockExistsSync.mockReturnValue(false);
+
+      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
+        {
+          token,
+          parameters: {
+            client_id: 'test-client-id',
+            framework: 'react',
+            project_path: '/tmp/project',
+          },
+        },
+        config
+      );
+      expect(response.isError).toBe(true);
+      expect(response.content[0].text).toContain('Environment file not found');
+      expect(response.content[0].text).toContain('auth0_save_credentials_to_file');
+    });
+
+    it('should skip .env check when spec has no envSnippet', async () => {
+      mockFetchQuickstartSpec.mockResolvedValue(makeMockSpec({ envSnippet: undefined }));
+      mockExistsSync.mockReturnValue(false);
+
+      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
+        {
+          token,
+          parameters: {
+            client_id: 'test-client-id',
+            framework: 'react',
+            project_path: '/tmp/project',
+          },
+        },
+        config
+      );
+      expect(response.isError).toBe(false);
+    });
+  });
+
+  describe('callback URL resolution and update', () => {
+    it('should append missing callback URLs to the application', async () => {
+      server.use(
+        http.get('https://*/api/v2/clients/:clientId', () => {
+          return HttpResponse.json({
+            ...mockAppData,
+            callbacks: [],
+            allowed_logout_urls: [],
+            web_origins: [],
+          });
+        }),
+        http.patch('https://*/api/v2/clients/:clientId', async ({ request }) => {
+          const body = (await request.json()) as Record<string, any>;
+          const allowedFields = [
+            'callbacks',
+            'allowed_logout_urls',
+            'web_origins',
+            'skip_non_verifiable_callback_uri_confirmation_prompt',
+          ];
+          for (const key of Object.keys(body)) {
+            expect(allowedFields).toContain(key);
+          }
+          expect(body.callbacks).toContain('http://localhost:3000/callback');
+          expect(body.allowed_logout_urls).toContain('http://localhost:3000/');
+          expect(body.web_origins).toContain('http://localhost:3000');
+          return HttpResponse.json({ ...mockAppData, ...body });
+        })
+      );
+
+      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
+        {
+          token,
+          parameters: {
+            client_id: 'test-client-id',
+            framework: 'react',
+            project_path: '/tmp/project',
+          },
+        },
+        config
+      );
+      expect(response.isError).toBe(false);
+    });
+
+    it('should not update when all URLs are already configured', async () => {
+      server.use(
+        http.get('https://*/api/v2/clients/:clientId', () => {
+          return HttpResponse.json({
+            ...mockAppData,
+            callbacks: ['http://localhost:3000/callback'],
+            allowed_logout_urls: ['http://localhost:3000/'],
+            web_origins: ['http://localhost:3000'],
+          });
+        }),
+        http.patch('https://*/api/v2/clients/:clientId', () => {
+          throw new Error('Should not call update when no URLs to add');
+        })
+      );
+
+      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
+        {
+          token,
+          parameters: {
+            client_id: 'test-client-id',
+            framework: 'react',
+            project_path: '/tmp/project',
+          },
+        },
+        config
+      );
+      expect(response.isError).toBe(false);
+      const result = JSON.parse(response.content[0].text);
+      expect(result.urls_updated).toBe(false);
+      expect(result.actions_taken).toEqual(['Fetched quickstart guide for react']);
+    });
+
+    it('should include specific URL values in actions_taken messages', async () => {
+      server.use(
+        http.get('https://*/api/v2/clients/:clientId', () => {
+          return HttpResponse.json({
+            ...mockAppData,
+            callbacks: [],
+            allowed_logout_urls: [],
+            web_origins: [],
+          });
+        })
+      );
+
+      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
+        {
+          token,
+          parameters: {
+            client_id: 'test-client-id',
+            framework: 'react',
+            project_path: '/tmp/project',
+          },
+        },
+        config
+      );
+      const result = JSON.parse(response.content[0].text);
+      expect(result.actions_taken).toContainEqual(
+        expect.stringContaining('Set callback URL(s): http://localhost:3000/callback')
+      );
+      expect(result.actions_taken).toContainEqual(
+        expect.stringContaining('Set logout URL(s): http://localhost:3000/')
+      );
+      expect(result.actions_taken).toContainEqual(
+        expect.stringContaining('Set allowed web origin(s): http://localhost:3000')
+      );
+      expect(result.actions_taken).toContain('Fetched quickstart guide for react');
+    });
+
+    it('should omit web_origins from actions_taken for webapp apps', async () => {
+      mockFetchQuickstartSpec.mockResolvedValue(makeMockSpec({ appType: 'webapp' }));
+
+      server.use(
+        http.get('https://*/api/v2/clients/:clientId', () => {
+          return HttpResponse.json({ ...mockAppData, callbacks: [], allowed_logout_urls: [] });
+        })
+      );
+
+      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
+        {
+          token,
+          parameters: {
+            client_id: 'test-client-id',
+            framework: 'react',
+            project_path: '/tmp/project',
+          },
+        },
+        config
+      );
+      const result = JSON.parse(response.content[0].text);
+      expect(result.urls_updated).toBe(true);
+      expect(result.actions_taken).toContainEqual(expect.stringContaining('Set callback URL(s)'));
+      expect(result.actions_taken).toContainEqual(expect.stringContaining('Set logout URL(s)'));
+      expect(result.actions_taken).not.toContainEqual(expect.stringContaining('web origin'));
+    });
+
+    it('should report all non-empty finalUrls fields when any update is needed', async () => {
+      server.use(
+        http.get('https://*/api/v2/clients/:clientId', () => {
+          return HttpResponse.json({
+            ...mockAppData,
+            callbacks: ['http://localhost:3000/callback'],
+            allowed_logout_urls: [],
+            web_origins: ['http://localhost:3000'],
+          });
+        })
+      );
+
+      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
+        {
+          token,
+          parameters: {
+            client_id: 'test-client-id',
+            framework: 'react',
+            project_path: '/tmp/project',
+          },
+        },
+        config
+      );
+      const result = JSON.parse(response.content[0].text);
+      expect(result.urls_updated).toBe(true);
+      expect(result.actions_taken).toContainEqual(expect.stringContaining('Set callback URL(s)'));
+      expect(result.actions_taken).toContainEqual(expect.stringContaining('Set logout URL(s)'));
+      expect(result.actions_taken).toContainEqual(
+        expect.stringContaining('Set allowed web origin(s)')
+      );
+    });
+
+    it('should use base_url when provided', async () => {
+      server.use(
+        http.get('https://*/api/v2/clients/:clientId', () => {
+          return HttpResponse.json({
+            ...mockAppData,
+            callbacks: [],
+            allowed_logout_urls: [],
+            web_origins: [],
+          });
+        }),
+        http.patch('https://*/api/v2/clients/:clientId', async ({ request }) => {
+          const body = (await request.json()) as Record<string, any>;
+          expect(body.callbacks).toContain('http://localhost:4200/callback');
+          return HttpResponse.json({ ...mockAppData, ...body });
+        })
+      );
+
+      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
+        {
+          token,
+          parameters: {
+            client_id: 'test-client-id',
+            framework: 'react',
+            project_path: '/tmp/project',
+            base_url: 'http://localhost:4200',
+          },
+        },
+        config
+      );
+      expect(response.isError).toBe(false);
+      const result = JSON.parse(response.content[0].text);
+      expect(result.url_source).toBe('detected');
+    });
+
+    it('should preserve existing URLs when appending new ones', async () => {
+      server.use(
+        http.get('https://*/api/v2/clients/:clientId', () => {
+          return HttpResponse.json({
+            ...mockAppData,
+            callbacks: ['https://prod.example.com/callback'],
+            allowed_logout_urls: ['https://prod.example.com'],
+            web_origins: ['https://prod.example.com'],
+          });
+        }),
+        http.patch('https://*/api/v2/clients/:clientId', async ({ request }) => {
+          const body = (await request.json()) as Record<string, any>;
+          expect(body.callbacks).toContain('https://prod.example.com/callback');
+          expect(body.callbacks).toContain('http://localhost:3000/callback');
+          return HttpResponse.json({ ...mockAppData, ...body });
+        })
+      );
+
+      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
+        {
+          token,
+          parameters: {
+            client_id: 'test-client-id',
+            framework: 'react',
+            project_path: '/tmp/project',
+          },
+        },
+        config
+      );
+      expect(response.isError).toBe(false);
+    });
+
+    it('should not update when base_url is invalid', async () => {
+      let patchCalled = false;
+      server.use(
+        http.get('https://*/api/v2/clients/:clientId', () => {
+          return HttpResponse.json({
+            ...mockAppData,
+            callbacks: [],
+            allowed_logout_urls: [],
+            web_origins: [],
+          });
+        }),
+        http.patch('https://*/api/v2/clients/:clientId', () => {
+          patchCalled = true;
+          return HttpResponse.json(mockAppData);
+        })
+      );
+
+      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
+        {
+          token,
+          parameters: {
+            client_id: 'test-client-id',
+            framework: 'react',
+            project_path: '/tmp/project',
+            base_url: 'not-a-url',
+          },
+        },
+        config
+      );
+      expect(response.isError).toBe(true);
+      expect(response.content[0].text).toContain('Invalid resolved base URL');
+      expect(patchCalled).toBe(false);
+    });
+
+    it('should not call PATCH when calculateUrlUpdates finds no changes needed', async () => {
+      let patchCalled = false;
+      server.use(
+        http.get('https://*/api/v2/clients/:clientId', () => {
+          return HttpResponse.json({
+            ...mockAppData,
+            callbacks: ['http://localhost:3000/callback'],
+            allowed_logout_urls: ['http://localhost:3000/'],
+            web_origins: ['http://localhost:3000'],
+          });
+        }),
+        http.patch('https://*/api/v2/clients/:clientId', () => {
+          patchCalled = true;
+          return HttpResponse.json(mockAppData);
+        })
+      );
+
+      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
+        {
+          token,
+          parameters: {
+            client_id: 'test-client-id',
+            framework: 'react',
+            project_path: '/tmp/project',
+          },
+        },
+        config
+      );
+      expect(response.isError).toBe(false);
+      const result = JSON.parse(response.content[0].text);
+      expect(result.urls_updated).toBe(false);
+      expect(patchCalled).toBe(false);
+    });
+
+    it('should use the provided client_id in both GET and PATCH API calls', async () => {
+      let getCalled = false;
+      let patchCalledWithCorrectId = false;
+
+      server.use(
+        http.get('https://*/api/v2/clients/:clientId', ({ params }) => {
+          if (params.clientId === 'specific-client-123') {
+            getCalled = true;
+            return HttpResponse.json({
+              ...mockAppData,
+              client_id: 'specific-client-123',
+              callbacks: [],
+              allowed_logout_urls: [],
+              web_origins: [],
+            });
+          }
+          return new HttpResponse(null, { status: 404 });
+        }),
+        http.patch('https://*/api/v2/clients/:clientId', async ({ params, request }) => {
+          if (params.clientId === 'specific-client-123') {
+            patchCalledWithCorrectId = true;
+          }
+          const updates = (await request.json()) as Record<string, any>;
+          return HttpResponse.json({ ...mockAppData, ...updates });
+        })
+      );
+
+      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
+        {
+          token,
+          parameters: {
+            client_id: 'specific-client-123',
+            framework: 'react',
+            project_path: '/tmp/project',
+          },
+        },
+        config
+      );
+      expect(response.isError).toBe(false);
+      expect(getCalled).toBe(true);
+      expect(patchCalledWithCorrectId).toBe(true);
+    });
+
+    it('should only send allowed URL fields in PATCH payload', async () => {
+      let patchBody: Record<string, any> = {};
+      server.use(
+        http.get('https://*/api/v2/clients/:clientId', () => {
+          return HttpResponse.json({
+            ...mockAppData,
+            callbacks: [],
+            allowed_logout_urls: [],
+            web_origins: [],
+          });
+        }),
+        http.patch('https://*/api/v2/clients/:clientId', async ({ request }) => {
+          patchBody = (await request.json()) as Record<string, any>;
+          return HttpResponse.json({ ...mockAppData, ...patchBody });
+        })
+      );
+
+      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
+        {
+          token,
+          parameters: {
+            client_id: 'test-client-id',
+            framework: 'react',
+            project_path: '/tmp/project',
+          },
+        },
+        config
+      );
+      expect(response.isError).toBe(false);
+      expect(patchBody.callbacks).toBeDefined();
+      expect(patchBody.allowed_logout_urls).toBeDefined();
+      expect(patchBody.web_origins).toBeDefined();
+    });
+  });
+
+  describe('LLM prompt fetching', () => {
+    it('should return error when prompt fetch fails with 404', async () => {
+      let patchCalled = false;
+      server.use(
+        http.patch('https://*/api/v2/clients/:clientId', () => {
+          patchCalled = true;
+          return HttpResponse.json(mockAppData);
+        }),
+        http.get(MOCK_LLM_PROMPT_URL, () => {
+          return new HttpResponse(null, { status: 404 });
+        })
+      );
+
+      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
+        {
+          token,
+          parameters: {
+            client_id: 'test-client-id',
+            framework: 'react',
+            project_path: '/tmp/project',
+          },
+        },
+        config
+      );
+      expect(response.isError).toBe(true);
+      expect(response.content[0].text).toContain('Quickstart guide unavailable');
+      expect(patchCalled).toBe(false);
+    });
+
+    it('should return error when prompt fetch fails with 500', async () => {
+      let patchCalled = false;
+      server.use(
+        http.patch('https://*/api/v2/clients/:clientId', () => {
+          patchCalled = true;
+          return HttpResponse.json(mockAppData);
+        }),
+        http.get(MOCK_LLM_PROMPT_URL, () => {
+          return new HttpResponse(null, { status: 500 });
+        })
+      );
+
+      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
+        {
+          token,
+          parameters: {
+            client_id: 'test-client-id',
+            framework: 'react',
+            project_path: '/tmp/project',
+          },
+        },
+        config
+      );
+      expect(response.isError).toBe(true);
+      expect(response.content[0].text).toContain('Quickstart guide unavailable');
+      expect(patchCalled).toBe(false);
+    });
+
+    it('should return error on network failure', async () => {
+      let patchCalled = false;
+      server.use(
+        http.patch('https://*/api/v2/clients/:clientId', () => {
+          patchCalled = true;
+          return HttpResponse.json(mockAppData);
+        }),
+        http.get(MOCK_LLM_PROMPT_URL, () => {
+          return HttpResponse.error();
+        })
+      );
+
+      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
+        {
+          token,
+          parameters: {
+            client_id: 'test-client-id',
+            framework: 'react',
+            project_path: '/tmp/project',
+          },
+        },
+        config
+      );
+      expect(response.isError).toBe(true);
+      expect(response.content[0].text).toContain('Quickstart guide unavailable');
+      expect(patchCalled).toBe(false);
+    });
+  });
+
+  describe('placeholder injection', () => {
+    it('should inject domain and client_id placeholders', async () => {
+      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
+        {
+          token,
+          parameters: {
+            client_id: 'test-client-id',
+            framework: 'react',
+            project_path: '/tmp/project',
+          },
+        },
+        config
+      );
+      expect(response.isError).toBe(false);
+      const result = JSON.parse(response.content[0].text);
+      expect(result.quickstart_prompt).toContain('test-tenant.auth0.com');
+      expect(result.quickstart_prompt).toContain('test-client-id');
+      expect(result.quickstart_prompt).toContain('3000');
+      expect(result.quickstart_prompt).not.toContain('%AUTH0_DOMAIN%');
+      expect(result.quickstart_prompt).not.toContain('%AUTH0_CLIENT_ID%');
+      expect(result.quickstart_prompt).not.toContain('%PORT%');
+    });
+
+    it('should leave unresolvable placeholders unchanged', async () => {
+      mockFetchQuickstartSpec.mockResolvedValue(
+        makeMockSpec({
+          placeholders: {
+            '%AUTH0_DOMAIN%': { inputKey: 'auth0Domain' },
+            '%MISSING%': { inputKey: 'nonexistent' },
+          },
+        })
+      );
+
+      server.use(
+        http.get(MOCK_LLM_PROMPT_URL, () => {
+          return new HttpResponse('Domain: %AUTH0_DOMAIN% and %MISSING% here', { status: 200 });
+        })
+      );
+
+      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
+        {
+          token,
+          parameters: {
+            client_id: 'test-client-id',
+            framework: 'react',
+            project_path: '/tmp/project',
+          },
+        },
+        config
+      );
+      expect(response.isError).toBe(false);
+      const result = JSON.parse(response.content[0].text);
+      expect(result.quickstart_prompt).toContain('%MISSING%');
+      expect(result.quickstart_prompt).not.toContain('%AUTH0_DOMAIN%');
+    });
+  });
+
+  describe('success response', () => {
+    it('should return complete success response with all fields', async () => {
+      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
+        {
+          token,
+          parameters: {
+            client_id: 'test-client-id',
+            framework: 'react',
+            project_path: '/tmp/project',
+          },
+        },
+        config
+      );
+      expect(response.isError).toBe(false);
+      const result = JSON.parse(response.content[0].text);
+
+      expect(result.success).toBe(true);
+      expect(result.client_id).toBe('test-client-id');
+      expect(result.framework).toBe('react');
+      expect(result.project_path).toBe('/tmp/project');
+      expect(result.app_type).toBe('spa');
+      expect(result.quickstart_prompt).toBeDefined();
+      expect(result.configured_urls).toBeDefined();
+      expect(result.configured_urls.callbacks).toBeDefined();
+      expect(result.configured_urls.allowed_logout_urls).toBeDefined();
+      expect(result.url_source).toBeDefined();
+      expect(result.urls_updated).toBe(true);
+      expect(result.actions_taken).toBeInstanceOf(Array);
+      expect(result.actions_taken).toContain('Fetched quickstart guide for react');
+      expect(result.instructions).toContain('summarize actions_taken');
+    });
+
+    it('should include web_origins for SPA apps', async () => {
+      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
+        {
+          token,
+          parameters: {
+            client_id: 'test-client-id',
+            framework: 'react',
+            project_path: '/tmp/project',
+          },
+        },
+        config
+      );
+      const result = JSON.parse(response.content[0].text);
+      expect(result.configured_urls.web_origins).toBeDefined();
+    });
+
+    it('should omit web_origins for webapp apps', async () => {
+      mockFetchQuickstartSpec.mockResolvedValue(makeMockSpec({ appType: 'webapp' }));
+
+      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
+        {
+          token,
+          parameters: {
+            client_id: 'test-client-id',
+            framework: 'react',
+            project_path: '/tmp/project',
+          },
+        },
+        config
+      );
+      const result = JSON.parse(response.content[0].text);
+      expect(result.configured_urls.web_origins).toBeUndefined();
+    });
+
+    it('should set url_source to framework_default when no base_url provided', async () => {
+      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
+        {
+          token,
+          parameters: {
+            client_id: 'test-client-id',
+            framework: 'react',
+            project_path: '/tmp/project',
+          },
+        },
+        config
+      );
+      const result = JSON.parse(response.content[0].text);
+      expect(result.url_source).toBe('framework_default');
+    });
+
+    it('should set url_source to detected when base_url is provided', async () => {
+      server.use(
+        http.get('https://*/api/v2/clients/:clientId', () => {
+          return HttpResponse.json({
+            ...mockAppData,
+            callbacks: [],
+            allowed_logout_urls: [],
+            web_origins: [],
+          });
+        })
+      );
+
+      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
+        {
+          token,
+          parameters: {
+            client_id: 'test-client-id',
+            framework: 'react',
+            project_path: '/tmp/project',
+            base_url: 'http://localhost:4200',
+          },
+        },
+        config
+      );
+      const result = JSON.parse(response.content[0].text);
+      expect(result.url_source).toBe('detected');
+    });
+  });
+
+  describe('non-verifiable callback detection', () => {
+    it('should include skip flag when localhost callbacks are configured', async () => {
+      server.use(
+        http.get('https://*/api/v2/clients/:clientId', () => {
+          return HttpResponse.json({
+            ...mockAppData,
+            callbacks: [],
+            allowed_logout_urls: [],
+            web_origins: [],
+          });
+        })
+      );
+
+      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
+        {
+          token,
+          parameters: {
+            client_id: 'test-client-id',
+            framework: 'react',
+            project_path: '/tmp/project',
+          },
+        },
+        config
+      );
+      const result = JSON.parse(response.content[0].text);
+      expect(result.configured_urls.skip_non_verifiable_callback_uri_confirmation_prompt).toBe(
+        true
+      );
+    });
+
+    it('should not include skip flag when only HTTPS production URLs exist', async () => {
+      mockFetchQuickstartSpec.mockResolvedValue(
+        makeMockSpec({
+          defaultAppOrigin: { scheme: 'https', domain: 'myapp.com' },
+        })
+      );
+
+      server.use(
+        http.get('https://*/api/v2/clients/:clientId', () => {
+          return HttpResponse.json({
+            ...mockAppData,
+            callbacks: ['https://myapp.com/callback'],
+            allowed_logout_urls: ['https://myapp.com/'],
+            web_origins: ['https://myapp.com'],
+          });
+        })
+      );
+
+      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
+        {
+          token,
+          parameters: {
+            client_id: 'test-client-id',
+            framework: 'react',
+            project_path: '/tmp/project',
+          },
+        },
+        config
+      );
+      const result = JSON.parse(response.content[0].text);
+      expect(
+        result.configured_urls.skip_non_verifiable_callback_uri_confirmation_prompt
+      ).toBeUndefined();
+    });
+  });
+
+  describe('defensive error handling', () => {
+    it('should handle application GET returning an error gracefully', async () => {
+      server.use(
+        http.get('https://*/api/v2/clients/:clientId', () => {
+          return new HttpResponse(
+            JSON.stringify({ statusCode: 500, message: 'Internal Server Error' }),
+            {
+              status: 500,
+            }
+          );
+        })
+      );
+
+      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
+        {
+          token,
+          parameters: {
+            client_id: 'test-client-id',
+            framework: 'react',
+            project_path: '/tmp/project',
+          },
+        },
+        config
+      );
+      expect(response.isError).toBe(true);
+      expect(response.content[0].text).toBeDefined();
+    });
+
+    it('should handle update error with malformed response gracefully', async () => {
+      server.use(
+        http.get('https://*/api/v2/clients/:clientId', () => {
+          return HttpResponse.json({
+            ...mockAppData,
+            callbacks: [],
+            allowed_logout_urls: [],
+            web_origins: [],
+          });
+        }),
+        http.patch('https://*/api/v2/clients/:clientId', () => {
+          return new HttpResponse(JSON.stringify({ error: 'forbidden' }), { status: 403 });
+        })
+      );
+
+      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
+        {
+          token,
+          parameters: {
+            client_id: 'test-client-id',
+            framework: 'react',
+            project_path: '/tmp/project',
+          },
+        },
+        config
+      );
+      expect(response.isError).toBe(true);
+      expect(response.content[0].text).toContain('Failed to update application callback URLs');
+    });
+  });
+
+  describe('path traversal protection', () => {
+    it('should reject project_path containing traversal sequences', async () => {
+      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
+        {
+          token,
+          parameters: {
+            client_id: 'test-client-id',
+            framework: 'react',
+            project_path: '../../etc',
+          },
+        },
+        config
+      );
+      expect(response.isError).toBe(true);
+      expect(response.content[0].text).toContain('path traversal');
+    });
+
+    it('should reject deeply nested traversal', async () => {
+      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
+        {
+          token,
+          parameters: {
+            client_id: 'test-client-id',
+            framework: 'react',
+            project_path: '/tmp/project/../../../etc/passwd',
+          },
+        },
+        config
+      );
+      expect(response.isError).toBe(true);
+      expect(response.content[0].text).toContain('path traversal');
+    });
+  });
+
+  describe('project_path directory validation', () => {
+    it('should reject project_path that is not an existing directory', async () => {
+      mockStatSync.mockReturnValue(null);
+
+      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
+        {
+          token,
+          parameters: {
+            client_id: 'test-client-id',
+            framework: 'react',
+            project_path: '/tmp/project',
+          },
+        },
+        config
+      );
+      expect(response.isError).toBe(true);
+      expect(response.content[0].text).toContain('must be an existing directory');
+    });
+
+    it('should reject project_path that is a file', async () => {
+      mockStatSync.mockReturnValue({ isDirectory: () => false });
+
+      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
+        {
+          token,
+          parameters: {
+            client_id: 'test-client-id',
+            framework: 'react',
+            project_path: '/tmp/project',
+          },
+        },
+        config
+      );
+      expect(response.isError).toBe(true);
+      expect(response.content[0].text).toContain('must be an existing directory');
+    });
+
+    it('should reject project_path when statSync returns undefined (throwIfNoEntry: false)', async () => {
+      mockStatSync.mockReturnValue(undefined);
+
+      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
+        {
+          token,
+          parameters: {
+            client_id: 'test-client-id',
+            framework: 'react',
+            project_path: '/tmp/nonexistent',
+          },
+        },
+        config
+      );
+      expect(response.isError).toBe(true);
+      expect(response.content[0].text).toContain('must be an existing directory');
+    });
+  });
+
+  describe('framework validation', () => {
+    it('should reject unsupported framework values', async () => {
+      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
+        {
+          token,
+          parameters: {
+            client_id: 'test-client-id',
+            framework: 'svelte',
+            project_path: '/tmp/project',
+          },
+        },
+        config
+      );
+      expect(response.isError).toBe(true);
+      expect(response.content[0].text).toContain('Unsupported framework');
+      expect(response.content[0].text).toContain('react, vue, angular, nextjs');
+    });
+
+    it('should reject mixed-case framework values', async () => {
+      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
+        {
+          token,
+          parameters: {
+            client_id: 'test-client-id',
+            framework: 'React',
+            project_path: '/tmp/project',
+          },
+        },
+        config
+      );
+      expect(response.isError).toBe(true);
+      expect(response.content[0].text).toContain('Unsupported framework');
+      expect(response.content[0].text).toContain('React');
+    });
+  });
+
+  describe('port injection logic', () => {
+    it('should use spec default port when base_url has no explicit port', async () => {
+      mockFetchQuickstartSpec.mockResolvedValue(
+        makeMockSpec({ defaultAppOrigin: { scheme: 'http', domain: 'localhost', port: 3000 } })
+      );
+
+      server.use(
+        http.get('https://*/api/v2/clients/:clientId', () => {
+          return HttpResponse.json({
+            ...mockAppData,
+            callbacks: [],
+            allowed_logout_urls: [],
+            web_origins: [],
+          });
+        })
+      );
+
+      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
+        {
+          token,
+          parameters: {
+            client_id: 'test-client-id',
+            framework: 'react',
+            project_path: '/tmp/project',
+            base_url: 'http://localhost',
+          },
+        },
+        config
+      );
+      expect(response.isError).toBe(false);
+      const result = JSON.parse(response.content[0].text);
+      expect(result.quickstart_prompt).toContain('3000');
+    });
+
+    it('should use explicit URL port over spec default', async () => {
+      mockFetchQuickstartSpec.mockResolvedValue(
+        makeMockSpec({ defaultAppOrigin: { scheme: 'http', domain: 'localhost', port: 3000 } })
+      );
+
+      server.use(
+        http.get('https://*/api/v2/clients/:clientId', () => {
+          return HttpResponse.json({
+            ...mockAppData,
+            callbacks: [],
+            allowed_logout_urls: [],
+            web_origins: [],
+          });
+        })
+      );
+
+      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
+        {
+          token,
+          parameters: {
+            client_id: 'test-client-id',
+            framework: 'react',
+            project_path: '/tmp/project',
+            base_url: 'http://localhost:8080',
+          },
+        },
+        config
+      );
+      expect(response.isError).toBe(false);
+      const result = JSON.parse(response.content[0].text);
+      expect(result.quickstart_prompt).toContain('8080');
+    });
+
+    it('should fall back to 443 for HTTPS when no port in URL or spec', async () => {
+      mockFetchQuickstartSpec.mockResolvedValue(
+        makeMockSpec({ defaultAppOrigin: { scheme: 'https', domain: 'myapp.com' } })
+      );
+
+      server.use(
+        http.get('https://*/api/v2/clients/:clientId', () => {
+          return HttpResponse.json({ ...mockAppData, callbacks: [], allowed_logout_urls: [] });
+        })
+      );
+
+      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
+        {
+          token,
+          parameters: {
+            client_id: 'test-client-id',
+            framework: 'react',
+            project_path: '/tmp/project',
+            base_url: 'https://myapp.com',
+          },
+        },
+        config
+      );
+      expect(response.isError).toBe(false);
+      const result = JSON.parse(response.content[0].text);
+      expect(result.quickstart_prompt).toContain('443');
+    });
+
+    it('should fall back to 80 for HTTP when no port in URL or spec', async () => {
+      mockFetchQuickstartSpec.mockResolvedValue(
+        makeMockSpec({ defaultAppOrigin: { scheme: 'http', domain: 'localhost' } })
+      );
+
+      server.use(
+        http.get('https://*/api/v2/clients/:clientId', () => {
+          return HttpResponse.json({
+            ...mockAppData,
+            callbacks: [],
+            allowed_logout_urls: [],
+            web_origins: [],
+          });
+        })
+      );
+
+      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
+        {
+          token,
+          parameters: {
+            client_id: 'test-client-id',
+            framework: 'react',
+            project_path: '/tmp/project',
+            base_url: 'http://localhost',
+          },
+        },
+        config
+      );
+      expect(response.isError).toBe(false);
+      const result = JSON.parse(response.content[0].text);
+      expect(result.quickstart_prompt).toContain('80');
+    });
+  });
+});

--- a/test/tools/quickstarts.test.ts
+++ b/test/tools/quickstarts.test.ts
@@ -890,6 +890,23 @@ describe('auth0_get_quickstart_guide', () => {
       expect(result.instructions).toContain('summarize actions_taken');
     });
 
+    it('should return the normalized resolved path, not the raw input', async () => {
+      const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
+        {
+          token,
+          parameters: {
+            client_id: 'test-client-id',
+            framework: 'react',
+            project_path: '/tmp/project/sub/..',
+          },
+        },
+        config
+      );
+      expect(response.isError).toBe(false);
+      const result = JSON.parse(response.content[0].text);
+      expect(result.project_path).toBe('/tmp/project');
+    });
+
     it('should include web_origins for SPA apps', async () => {
       const response = await QUICKSTART_HANDLERS.auth0_get_quickstart_guide(
         {

--- a/test/tools/quickstarts.test.ts
+++ b/test/tools/quickstarts.test.ts
@@ -120,10 +120,10 @@ describe('auth0_get_quickstart_guide', () => {
   });
 
   describe('tool metadata', () => {
-    it('should mark the tool as non-read-only and non-destructive (URL updates are additive)', () => {
+    it('should mark the tool as non-read-only and destructive (it updates the Auth0 application)', () => {
       const tool = QUICKSTART_TOOLS.find((t) => t.name === 'auth0_get_quickstart_guide');
       expect(tool?.annotations?.readOnlyHint).toBe(false);
-      expect(tool?.annotations?.destructiveHint).toBe(false);
+      expect(tool?.annotations?.destructiveHint).toBe(true);
     });
   });
 

--- a/test/utils/env-credentials.test.ts
+++ b/test/utils/env-credentials.test.ts
@@ -120,6 +120,17 @@ beforeEach(() => {
 });
 
 describe('resolveAndWriteCredentials — project path validation', () => {
+  it('returns error when project_path is not absolute', async () => {
+    const result = await resolveAndWriteCredentials(
+      { ...fallbackParams, project_path: 'myapp' },
+      config,
+      token
+    );
+
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain('must be an absolute path');
+  });
+
   it('returns error when project_path does not exist', async () => {
     vi.mocked(fs.existsSync).mockReturnValue(false);
 

--- a/test/utils/quickstart-guide.test.ts
+++ b/test/utils/quickstart-guide.test.ts
@@ -1,68 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import {
-  hasNonVerifiableCallbacks,
-  resolvePlaceholders,
-  calculateUrlUpdates,
-} from '../../src/utils/quickstart-guide';
+import { resolvePlaceholders, calculateUrlUpdates } from '../../src/utils/quickstart-guide';
 import { UrlSource } from '../../src/utils/onboarding';
-
-describe('hasNonVerifiableCallbacks', () => {
-  it('should return true for localhost', () => {
-    expect(hasNonVerifiableCallbacks(['http://localhost:3000/callback'])).toBe(true);
-  });
-
-  it('should return true for 127.0.0.1', () => {
-    expect(hasNonVerifiableCallbacks(['http://127.0.0.1:3000/callback'])).toBe(true);
-  });
-
-  it('should return true for 127.x.x.x variants', () => {
-    expect(hasNonVerifiableCallbacks(['http://127.0.0.2:8080/callback'])).toBe(true);
-    expect(hasNonVerifiableCallbacks(['http://127.255.255.255/callback'])).toBe(true);
-  });
-
-  it('should return true for [::1]', () => {
-    expect(hasNonVerifiableCallbacks(['http://[::1]:3000/callback'])).toBe(true);
-  });
-
-  it('should return true for custom URI schemes', () => {
-    expect(hasNonVerifiableCallbacks(['myapp://callback'])).toBe(true);
-    expect(hasNonVerifiableCallbacks(['exp://192.168.1.1:8081'])).toBe(true);
-  });
-
-  it('should return false for HTTPS production URLs', () => {
-    expect(hasNonVerifiableCallbacks(['https://myapp.com/callback'])).toBe(false);
-    expect(hasNonVerifiableCallbacks(['https://app.example.com/auth/callback'])).toBe(false);
-  });
-
-  it('should return false for HTTP non-loopback URLs', () => {
-    expect(hasNonVerifiableCallbacks(['http://myapp.com/callback'])).toBe(false);
-  });
-
-  it('should return true if any URL is non-verifiable', () => {
-    expect(
-      hasNonVerifiableCallbacks([
-        'https://prod.example.com/callback',
-        'http://localhost:3000/callback',
-      ])
-    ).toBe(true);
-  });
-
-  it('should return false for empty array', () => {
-    expect(hasNonVerifiableCallbacks([])).toBe(false);
-  });
-
-  it('should return true for unparseable URLs', () => {
-    expect(hasNonVerifiableCallbacks(['not-a-url'])).toBe(true);
-  });
-
-  it('should return true for 0.0.0.0', () => {
-    expect(hasNonVerifiableCallbacks(['http://0.0.0.0:3000/callback'])).toBe(true);
-  });
-
-  it('should return true for [::1] with different ports', () => {
-    expect(hasNonVerifiableCallbacks(['http://[::1]:8080/callback'])).toBe(true);
-  });
-});
 
 describe('resolvePlaceholders', () => {
   const placeholders = {

--- a/test/utils/quickstart-guide.test.ts
+++ b/test/utils/quickstart-guide.test.ts
@@ -1,0 +1,332 @@
+import { describe, it, expect } from 'vitest';
+import {
+  hasNonVerifiableCallbacks,
+  resolvePlaceholders,
+  calculateUrlUpdates,
+} from '../../src/utils/quickstart-guide';
+import { UrlSource } from '../../src/utils/onboarding';
+
+describe('hasNonVerifiableCallbacks', () => {
+  it('should return true for localhost', () => {
+    expect(hasNonVerifiableCallbacks(['http://localhost:3000/callback'])).toBe(true);
+  });
+
+  it('should return true for 127.0.0.1', () => {
+    expect(hasNonVerifiableCallbacks(['http://127.0.0.1:3000/callback'])).toBe(true);
+  });
+
+  it('should return true for 127.x.x.x variants', () => {
+    expect(hasNonVerifiableCallbacks(['http://127.0.0.2:8080/callback'])).toBe(true);
+    expect(hasNonVerifiableCallbacks(['http://127.255.255.255/callback'])).toBe(true);
+  });
+
+  it('should return true for [::1]', () => {
+    expect(hasNonVerifiableCallbacks(['http://[::1]:3000/callback'])).toBe(true);
+  });
+
+  it('should return true for custom URI schemes', () => {
+    expect(hasNonVerifiableCallbacks(['myapp://callback'])).toBe(true);
+    expect(hasNonVerifiableCallbacks(['exp://192.168.1.1:8081'])).toBe(true);
+  });
+
+  it('should return false for HTTPS production URLs', () => {
+    expect(hasNonVerifiableCallbacks(['https://myapp.com/callback'])).toBe(false);
+    expect(hasNonVerifiableCallbacks(['https://app.example.com/auth/callback'])).toBe(false);
+  });
+
+  it('should return false for HTTP non-loopback URLs', () => {
+    expect(hasNonVerifiableCallbacks(['http://myapp.com/callback'])).toBe(false);
+  });
+
+  it('should return true if any URL is non-verifiable', () => {
+    expect(
+      hasNonVerifiableCallbacks([
+        'https://prod.example.com/callback',
+        'http://localhost:3000/callback',
+      ])
+    ).toBe(true);
+  });
+
+  it('should return false for empty array', () => {
+    expect(hasNonVerifiableCallbacks([])).toBe(false);
+  });
+
+  it('should return true for unparseable URLs', () => {
+    expect(hasNonVerifiableCallbacks(['not-a-url'])).toBe(true);
+  });
+
+  it('should return true for 0.0.0.0', () => {
+    expect(hasNonVerifiableCallbacks(['http://0.0.0.0:3000/callback'])).toBe(true);
+  });
+
+  it('should return true for [::1] with different ports', () => {
+    expect(hasNonVerifiableCallbacks(['http://[::1]:8080/callback'])).toBe(true);
+  });
+});
+
+describe('resolvePlaceholders', () => {
+  const placeholders = {
+    '%AUTH0_DOMAIN%': { inputKey: 'auth0Domain' },
+    '%AUTH0_CLIENT_ID%': { inputKey: 'auth0ClientId' },
+    '%PORT%': { inputKey: 'port' },
+    '%APP_SCHEME%': { inputKey: 'appScheme' },
+    '%APP_DOMAIN%': { inputKey: 'appDomain' },
+    '%SDK_VERSION%': '2.x',
+    '%GIT_REMOTE%': { environmentKey: 'gitRemote' },
+    '%GIT_BRANCH%': { environmentKey: 'gitBranch' },
+    '{import.meta.env.VITE_AUTH0_DOMAIN}': { inputKey: 'auth0Domain', prefix: '"', suffix: '"' },
+  };
+
+  const inputValues = {
+    auth0Domain: 'tenant.auth0.com',
+    auth0ClientId: 'abc123',
+    port: '5173',
+    appDomain: 'localhost',
+    appScheme: 'http',
+  };
+
+  const environment = {
+    gitRemote: 'https://github.com/auth0-samples/auth0-react-samples',
+    gitBranch: 'quickstart/login',
+  };
+
+  it('should resolve inputKey placeholders', () => {
+    const result = resolvePlaceholders(
+      'Domain: %AUTH0_DOMAIN%, ID: %AUTH0_CLIENT_ID%',
+      placeholders,
+      inputValues,
+      environment
+    );
+    expect(result).toBe('Domain: tenant.auth0.com, ID: abc123');
+  });
+
+  it('should resolve static string placeholders', () => {
+    const result = resolvePlaceholders(
+      'npm install @auth0/auth0-react@%SDK_VERSION%',
+      placeholders,
+      inputValues,
+      environment
+    );
+    expect(result).toBe('npm install @auth0/auth0-react@2.x');
+  });
+
+  it('should resolve environmentKey placeholders', () => {
+    const result = resolvePlaceholders(
+      'git clone -b %GIT_BRANCH% %GIT_REMOTE%',
+      placeholders,
+      inputValues,
+      environment
+    );
+    expect(result).toBe(
+      'git clone -b quickstart/login https://github.com/auth0-samples/auth0-react-samples'
+    );
+  });
+
+  it('should apply prefix and suffix wrapping', () => {
+    const result = resolvePlaceholders(
+      'domain={import.meta.env.VITE_AUTH0_DOMAIN}',
+      placeholders,
+      inputValues,
+      environment
+    );
+    expect(result).toBe('domain="tenant.auth0.com"');
+  });
+
+  it('should leave unresolvable placeholders unchanged', () => {
+    const result = resolvePlaceholders(
+      'Value: %UNKNOWN%',
+      { '%UNKNOWN%': { inputKey: 'nonexistent' } },
+      inputValues,
+      environment
+    );
+    expect(result).toBe('Value: %UNKNOWN%');
+  });
+
+  it('should handle prompts with no matching placeholders', () => {
+    const result = resolvePlaceholders(
+      'No placeholders here',
+      placeholders,
+      inputValues,
+      environment
+    );
+    expect(result).toBe('No placeholders here');
+  });
+
+  it('should handle multiple occurrences of the same placeholder', () => {
+    const result = resolvePlaceholders('%PORT% and %PORT%', placeholders, inputValues, environment);
+    expect(result).toBe('5173 and 5173');
+  });
+
+  it('should handle empty placeholders map', () => {
+    const result = resolvePlaceholders('%PORT%', {}, inputValues, environment);
+    expect(result).toBe('%PORT%');
+  });
+
+  it('should handle empty string prompt', () => {
+    const result = resolvePlaceholders('', placeholders, inputValues, environment);
+    expect(result).toBe('');
+  });
+
+  it('should not recursively expand values containing placeholder syntax', () => {
+    const result = resolvePlaceholders(
+      'Domain: %AUTH0_DOMAIN%',
+      { '%AUTH0_DOMAIN%': { inputKey: 'auth0Domain' } },
+      { auth0Domain: '%PORT%' },
+      environment
+    );
+    expect(result).toBe('Domain: %PORT%');
+  });
+
+  it('should leave placeholder unchanged when environmentKey is missing', () => {
+    const result = resolvePlaceholders(
+      'URL: %DOWNLOAD_URL%',
+      { '%DOWNLOAD_URL%': { environmentKey: 'downloadUrl' } },
+      inputValues,
+      {}
+    );
+    expect(result).toBe('URL: %DOWNLOAD_URL%');
+  });
+});
+
+describe('calculateUrlUpdates', () => {
+  const baseResolvedUrls = {
+    base_url: 'http://localhost:3000',
+    callback_urls: ['http://localhost:3000/callback'],
+    logout_urls: ['http://localhost:3000/'],
+    web_origins: ['http://localhost:3000'],
+    url_source: UrlSource.FrameworkDefault,
+  };
+
+  it('should detect all URLs as new when app has none', () => {
+    const currentApp = { callbacks: [], allowed_logout_urls: [], web_origins: [] };
+    const { updatePayload, finalUrls } = calculateUrlUpdates(baseResolvedUrls, currentApp);
+
+    expect(updatePayload).not.toBeNull();
+    expect(updatePayload!.callbacks).toEqual(['http://localhost:3000/callback']);
+    expect(updatePayload!.allowed_logout_urls).toEqual(['http://localhost:3000/']);
+    expect(updatePayload!.web_origins).toEqual(['http://localhost:3000']);
+    expect(finalUrls.callbacks).toEqual(['http://localhost:3000/callback']);
+    expect(finalUrls.allowed_logout_urls).toEqual(['http://localhost:3000/']);
+    expect(finalUrls.web_origins).toEqual(['http://localhost:3000']);
+  });
+
+  it('should return null updatePayload when all URLs already exist', () => {
+    const currentApp = {
+      callbacks: ['http://localhost:3000/callback'],
+      allowed_logout_urls: ['http://localhost:3000/'],
+      web_origins: ['http://localhost:3000'],
+    };
+    const { updatePayload } = calculateUrlUpdates(baseResolvedUrls, currentApp);
+    expect(updatePayload).toBeNull();
+  });
+
+  it('should append new URLs while preserving existing ones', () => {
+    const currentApp = {
+      callbacks: ['https://prod.example.com/callback'],
+      allowed_logout_urls: ['https://prod.example.com'],
+      web_origins: ['https://prod.example.com'],
+    };
+    const { updatePayload, finalUrls } = calculateUrlUpdates(baseResolvedUrls, currentApp);
+
+    expect(updatePayload!.callbacks).toEqual([
+      'https://prod.example.com/callback',
+      'http://localhost:3000/callback',
+    ]);
+    expect(finalUrls.callbacks).toEqual([
+      'https://prod.example.com/callback',
+      'http://localhost:3000/callback',
+    ]);
+  });
+
+  it('should only include fields with additions in the update payload', () => {
+    const currentApp = {
+      callbacks: ['http://localhost:3000/callback'],
+      allowed_logout_urls: [],
+      web_origins: ['http://localhost:3000'],
+    };
+    const { updatePayload } = calculateUrlUpdates(baseResolvedUrls, currentApp);
+
+    expect(updatePayload!.callbacks).toBeUndefined();
+    expect(updatePayload!.allowed_logout_urls).toEqual(['http://localhost:3000/']);
+    expect(updatePayload!.web_origins).toBeUndefined();
+  });
+
+  it('should set skip_non_verifiable flag for localhost callbacks', () => {
+    const currentApp = { callbacks: [], allowed_logout_urls: [], web_origins: [] };
+    const { updatePayload, finalUrls } = calculateUrlUpdates(baseResolvedUrls, currentApp);
+
+    expect(updatePayload!.skip_non_verifiable_callback_uri_confirmation_prompt).toBe(true);
+    expect(finalUrls.skip_non_verifiable_callback_uri_confirmation_prompt).toBe(true);
+  });
+
+  it('should not set skip_non_verifiable flag when no update is needed even with localhost URLs', () => {
+    const currentApp = {
+      callbacks: ['http://localhost:3000/callback'],
+      allowed_logout_urls: ['http://localhost:3000/'],
+      web_origins: ['http://localhost:3000'],
+    };
+    const { updatePayload, finalUrls } = calculateUrlUpdates(baseResolvedUrls, currentApp);
+
+    expect(updatePayload).toBeNull();
+    expect(finalUrls.skip_non_verifiable_callback_uri_confirmation_prompt).toBeUndefined();
+  });
+
+  it('should not set skip_non_verifiable flag for production URLs', () => {
+    const resolvedUrls = {
+      base_url: 'https://myapp.com',
+      callback_urls: ['https://myapp.com/callback'],
+      logout_urls: ['https://myapp.com/'],
+      web_origins: ['https://myapp.com'],
+      url_source: UrlSource.Detected,
+    };
+    const currentApp = { callbacks: [], allowed_logout_urls: [], web_origins: [] };
+    const { updatePayload, finalUrls } = calculateUrlUpdates(resolvedUrls, currentApp);
+
+    expect(updatePayload!.skip_non_verifiable_callback_uri_confirmation_prompt).toBeUndefined();
+    expect(finalUrls.skip_non_verifiable_callback_uri_confirmation_prompt).toBeUndefined();
+  });
+
+  it('should handle missing fields in currentApp gracefully', () => {
+    const currentApp = {};
+    const { updatePayload } = calculateUrlUpdates(baseResolvedUrls, currentApp);
+
+    expect(updatePayload).not.toBeNull();
+    expect(updatePayload!.callbacks).toEqual(['http://localhost:3000/callback']);
+  });
+
+  it('should handle resolved URLs without web_origins (non-SPA)', () => {
+    const resolvedUrls = {
+      base_url: 'http://localhost:3000',
+      callback_urls: ['http://localhost:3000/callback'],
+      logout_urls: ['http://localhost:3000/'],
+      url_source: UrlSource.FrameworkDefault,
+    };
+    const currentApp = { callbacks: [], allowed_logout_urls: [] };
+    const { updatePayload, finalUrls } = calculateUrlUpdates(resolvedUrls, currentApp);
+
+    expect(updatePayload!.web_origins).toBeUndefined();
+    expect(finalUrls.web_origins).toBeUndefined();
+  });
+
+  it('should handle currentApp with undefined URL fields', () => {
+    const currentApp = {
+      callbacks: undefined,
+      allowed_logout_urls: undefined,
+      web_origins: undefined,
+    };
+    const { updatePayload } = calculateUrlUpdates(baseResolvedUrls, currentApp);
+
+    expect(updatePayload).not.toBeNull();
+    expect(updatePayload!.callbacks).toEqual(['http://localhost:3000/callback']);
+    expect(updatePayload!.allowed_logout_urls).toEqual(['http://localhost:3000/']);
+    expect(updatePayload!.web_origins).toEqual(['http://localhost:3000']);
+  });
+
+  it('should handle currentApp with null URL fields', () => {
+    const currentApp = { callbacks: null, allowed_logout_urls: null, web_origins: null };
+    const { updatePayload } = calculateUrlUpdates(baseResolvedUrls, currentApp);
+
+    expect(updatePayload).not.toBeNull();
+    expect(updatePayload!.callbacks).toEqual(['http://localhost:3000/callback']);
+  });
+});

--- a/test/utils/quickstarts.test.ts
+++ b/test/utils/quickstarts.test.ts
@@ -33,7 +33,7 @@ const makeMockRawSpec = (framework: string) => ({
   defaultAppOrigin: { scheme: 'http', domain: 'localhost', port: 3000 },
   callbackPath: '/callback',
   logoutPath: '/logout',
-  llmPromptPath: `https://example.com/${framework}-prompt`,
+  llmPromptPath: `assets/llm-prompts/${framework}-llm-prompt.md`,
   envSnippet: {
     type: 'env',
     language: 'shell',
@@ -57,7 +57,8 @@ const makeExpectedSpec = (framework: string) => ({
   defaultAppOrigin: { scheme: 'http', domain: 'localhost', port: 3000 },
   callbackPath: '/callback',
   logoutPath: '/logout',
-  llmPromptPath: `https://example.com/${framework}-prompt`,
+  llmPromptPath: `assets/llm-prompts/${framework}-llm-prompt.md`,
+  llmPromptUrl: `${CDN_BASE}/versions/${MOCK_VERSION}/assets/llm-prompts/${framework}-llm-prompt.md`,
   envSnippet: {
     type: 'env',
     language: 'shell',
@@ -98,6 +99,62 @@ describe('fetchQuickstartSpec', () => {
     expect(spec).toEqual(makeExpectedSpec('react'));
   });
 
+  it('ignores raw absolute llmPromptUrl and derives the prompt URL from llmPromptPath', async () => {
+    server.use(
+      mockLatest(),
+      http.get(defUrl('react'), () =>
+        HttpResponse.json({
+          ...makeMockRawSpec('react'),
+          llmPromptUrl: 'https://attacker.example/prompt.md',
+        })
+      )
+    );
+
+    const spec = await fetchQuickstartSpec('react');
+    expect(spec?.llmPromptUrl).toBe(
+      `${CDN_BASE}/versions/${MOCK_VERSION}/assets/llm-prompts/react-llm-prompt.md`
+    );
+  });
+
+  it('does not create a prompt URL from raw llmPromptUrl when llmPromptPath is absent', async () => {
+    server.use(
+      mockLatest(),
+      http.get(defUrl('react'), () =>
+        HttpResponse.json({
+          ...makeMockRawSpec('react'),
+          llmPromptPath: undefined,
+          llmPromptUrl: 'https://attacker.example/prompt.md',
+        })
+      )
+    );
+
+    const spec = await fetchQuickstartSpec('react');
+    expect(spec).not.toBeNull();
+    expect(spec?.llmPromptUrl).toBeUndefined();
+  });
+
+  it.each([
+    ['absolute URL', 'https://attacker.example/prompt.md'],
+    ['protocol-relative URL', '//attacker.example/prompt.md'],
+    ['absolute path', '/assets/llm-prompts/react-llm-prompt.md'],
+    ['path traversal', 'assets/llm-prompts/../definitions/react.md'],
+    ['encoded path traversal', 'assets/llm-prompts/%2e%2e/definitions/react.md'],
+    ['wrong prefix', 'assets/definitions/en/react.md'],
+  ])('returns null when llmPromptPath is an invalid %s', async (_caseName, llmPromptPath) => {
+    server.use(
+      mockLatest(),
+      http.get(defUrl('react'), () =>
+        HttpResponse.json({
+          ...makeMockRawSpec('react'),
+          llmPromptPath,
+        })
+      )
+    );
+
+    const spec = await fetchQuickstartSpec('react');
+    expect(spec).toBeNull();
+  });
+
   it('resolves URLs in two steps: production.json then versioned definition', async () => {
     const urls: string[] = [];
     server.use(
@@ -123,13 +180,10 @@ describe('fetchQuickstartSpec', () => {
     let capturedUrl = '';
     server.use(
       mockLatest(),
-      http.get(
-        defUrl(framework),
-        ({ request }) => {
-          capturedUrl = request.url;
-          return HttpResponse.json(makeMockRawSpec(framework));
-        }
-      )
+      http.get(defUrl(framework), ({ request }) => {
+        capturedUrl = request.url;
+        return HttpResponse.json(makeMockRawSpec(framework));
+      })
     );
     await fetchQuickstartSpec(framework);
     expect(capturedUrl).toContain(expectedFilename);


### PR DESCRIPTION
### Changes

Adds the `auth0_get_quickstart_guide` MCP tool, which fetches a framework-specific Auth0 quickstart implementation prompt, configures the application's callback URLs, and returns a ready-to-implement prompt.

- **New tool `auth0_get_quickstart_guide`** (`src/tools/quickstarts.ts`): given `client_id`, `framework`, and `project_path`, it resolves callback URLs from project config, fetches the quickstart LLM prompt from CDN, injects runtime values, updates the Auth0 application's callback/logout/web-origin URLs, and returns the resolved prompt. Requires `read:clients` and `update:clients`; marked `localOnly`. URL updates are additive and idempotent, so `destructiveHint` is `false`. Because the tool fetches from the CDN and writes to the Auth0 tenant, `openWorldHint` is `true`.
- **New utility `src/utils/quickstart-guide.ts`**: `resolvePlaceholders` (injects runtime values into the prompt template) and `calculateUrlUpdates` (computes the minimal application URL patch).
- **Secret masking**: client secret and session cookie secret placeholders are masked (`*******MASKED*********`) in the injected input values so secrets are never written into the returned prompt.
- **`.env` detection**: when a quickstart spec includes an env snippet, the tool detects an existing env file (e.g. `.env.development`) before falling back to the spec's preferred filename, and instructs the caller to reuse it rather than create a new one. The not-found error enumerates the expected filenames (`.env.local`, `.env`, `.env.development.local`, `.env.development`, plus the spec's snippet file).
- **Absolute `project_path` enforcement**: a relative path would resolve against the MCP server's stdio subprocess cwd (the client's launch dir), never the user's project — silently reading the wrong `.env`. The handler now rejects non-absolute paths, and the success response returns the normalized resolved path. The sibling `auth0_save_credentials_to_file` gets the same enforcement for a consistent `project_path` contract.
- Registered the tool in `src/tools/index.ts`.

### References

- https://auth0team.atlassian.net/browse/DXAA-555

### Testing

mcp-api e2e tests pass
<img width="2060" height="889" alt="image" src="https://github.com/user-attachments/assets/aefb0281-d4bb-48af-814d-62f5f240e391" />

Unit tests cover the new tool handler, the placeholder/URL-update utilities, and the shared onboarding helpers — including framework validation (valid, unsupported, and mixed-case), `.env` detection and missing-file handling, absolute-path enforcement (both tools), secret masking, callback-URL update calculation, and error paths (missing params, spec unavailable, app not found, CDN failure).

Run: `npx vitest run test/tools/quickstarts.test.ts test/utils/quickstart-guide.test.ts test/utils/onboarding.test.ts`

- [x] This change adds unit test coverage
- [ ] This change adds integration test coverage

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
