### PR TITLE
feat: add auth0_onboarding tool (DXAA-430)

### DIFF
--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -4,6 +4,7 @@ import { APPLICATION_GRANTS_HANDLERS, APPLICATION_GRANTS_TOOLS } from './applica
 import type { HandlerConfig, HandlerRequest, HandlerResponse, Tool } from '../utils/types.js';
 import { FORM_HANDLERS, FORM_TOOLS } from './forms.js';
 import { LOG_HANDLERS, LOG_TOOLS } from './logs.js';
+import { ONBOARDING_HANDLERS, ONBOARDING_TOOLS } from './onboarding.js';
 import { QUICKSTART_HANDLERS, QUICKSTART_TOOLS } from './quickstarts.js';
 import { RESOURCE_SERVER_HANDLERS, RESOURCE_SERVER_TOOLS } from './resource-servers.js';
 import trackEvent from '../utils/analytics.js';
@@ -16,6 +17,7 @@ export const TOOLS: Tool[] = [
   ...LOG_TOOLS,
   ...FORM_TOOLS,
   ...APPLICATION_GRANTS_TOOLS,
+  ...ONBOARDING_TOOLS,
   ...QUICKSTART_TOOLS,
 ];
 
@@ -27,6 +29,7 @@ const allHandlers = {
   ...LOG_HANDLERS,
   ...FORM_HANDLERS,
   ...APPLICATION_GRANTS_HANDLERS,
+  ...ONBOARDING_HANDLERS,
   ...QUICKSTART_HANDLERS,
 };
 

--- a/src/tools/onboarding.ts
+++ b/src/tools/onboarding.ts
@@ -19,7 +19,9 @@ export const ONBOARDING_TOOLS: Tool[] = [
     description:
       'Onboard a project with Auth0. Creates an Auth0 application with the correct ' +
       'configuration for the specified framework and saves credentials to a .env file. ' +
-      'Returns next_steps pointing to auth0_get_quickstart_guide tool to complete the integration.',
+      'Returns next_steps pointing to auth0_get_quickstart_guide tool to complete the integration. ' +
+      'Only supports frameworks listed in the enum. If the user\'s framework is not supported, ' +
+      'inform them that their framework is not yet supported and do NOT proceed with onboarding.',
     inputSchema: {
       type: 'object',
       properties: {

--- a/src/tools/onboarding.ts
+++ b/src/tools/onboarding.ts
@@ -165,7 +165,10 @@ export const ONBOARDING_HANDLERS: Record<
     );
 
     if (saveResponse.isError) {
-      return saveResponse;
+      const saveError = saveResponse.content[0]?.text ?? 'Unknown error';
+      return createErrorResponse(
+        `Error: Application "${resolvedAppName}" was created (client_id: ${clientId}) but credentials could not be saved. ${saveError}`
+      );
     }
 
     // Parse save response
@@ -182,8 +185,8 @@ export const ONBOARDING_HANDLERS: Record<
       domain: config.domain,
       app_type: mappedAppType,
       framework,
-      credentials_saved_to: saveData.credentials_saved_to,
-      keys_written: saveData.keys_written,
+      credentials_saved_to: saveData.credentials_saved_to ?? null,
+      keys_written: saveData.keys_written ?? [],
       next_steps: ['auth0_get_quickstart_guide'],
     });
   },

--- a/src/tools/onboarding.ts
+++ b/src/tools/onboarding.ts
@@ -51,7 +51,7 @@ export const ONBOARDING_TOOLS: Tool[] = [
       readOnlyHint: false,
       destructiveHint: true,
       idempotentHint: false,
-      openWorldHint: false,
+      openWorldHint: true,
     },
   },
 ];

--- a/src/tools/onboarding.ts
+++ b/src/tools/onboarding.ts
@@ -20,7 +20,7 @@ export const ONBOARDING_TOOLS: Tool[] = [
       'Onboard a project with Auth0. Creates an Auth0 application with the correct ' +
       'configuration for the specified framework and saves credentials to a .env file. ' +
       'Returns next_steps pointing to auth0_get_quickstart_guide tool to complete the integration. ' +
-      'Only supports frameworks listed in the enum. If the user\'s framework is not supported, ' +
+      "Only supports frameworks listed in the enum. If the user's framework is not supported, " +
       'inform them that their framework is not yet supported and do NOT proceed with onboarding.',
     inputSchema: {
       type: 'object',

--- a/src/tools/onboarding.ts
+++ b/src/tools/onboarding.ts
@@ -181,6 +181,14 @@ export const ONBOARDING_HANDLERS: Record<
       return createErrorResponse('Error: Failed to parse credentials save response');
     }
 
+    const credentialsAccessNote = appData._credentials_access
+      ? `Tell the user the client_secret is redacted in this response for security, and share the ` +
+        `dashboard and API URLs from _credentials_access so they know where to view the full secret. `
+      : '';
+    const skipPromptNote = appData.skip_non_verifiable_callback_uri_confirmation_prompt
+      ? `Also inform the user that skip_non_verifiable_callback_uri_confirmation_prompt was automatically enabled. `
+      : '';
+
     return createSuccessResponse({
       success: true,
       client_id: clientId,
@@ -189,7 +197,18 @@ export const ONBOARDING_HANDLERS: Record<
       framework,
       credentials_saved_to: saveData.credentials_saved_to ?? null,
       keys_written: saveData.keys_written ?? [],
+      ...(appData._credentials_access ? { _credentials_access: appData._credentials_access } : {}),
+      ...(appData.skip_non_verifiable_callback_uri_confirmation_prompt
+        ? { skip_non_verifiable_callback_uri_confirmation_prompt: true }
+        : {}),
       next_steps: ['auth0_get_quickstart_guide'],
+      instructions:
+        `The Auth0 application has been created, but onboarding is not yet complete. ` +
+        `This is the first of two steps. ${credentialsAccessNote}${skipPromptNote}` +
+        `Immediately call the auth0_get_quickstart_guide tool with ` +
+        `client_id "${clientId}", framework "${framework}", and project_path "${resolvedProjectPath}" ` +
+        `to perform the SDK integration. Do not wait for the user to ask, and do not tell the user ` +
+        `onboarding is complete until after auth0_get_quickstart_guide has finished.`,
     });
   },
 };

--- a/src/tools/onboarding.ts
+++ b/src/tools/onboarding.ts
@@ -1,0 +1,190 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import type { HandlerConfig, HandlerRequest, HandlerResponse, Tool } from '../utils/types.js';
+import { log } from '../utils/logger.js';
+import { createErrorResponse, createSuccessResponse } from '../utils/http-utility.js';
+import { fetchQuickstartSpec } from '../utils/quickstarts.js';
+import { isFrameworkSupported, SUPPORTED_FRAMEWORKS } from '../utils/onboarding.js';
+import { APPLICATION_HANDLERS } from './applications.js';
+
+const APP_TYPE_MAP: Record<string, string> = {
+  spa: 'spa',
+  webapp: 'regular_web',
+  native: 'native',
+};
+
+export const ONBOARDING_TOOLS: Tool[] = [
+  {
+    name: 'auth0_onboarding',
+    description:
+      'Onboard a project with Auth0. Creates an Auth0 application with the correct ' +
+      'configuration for the specified framework and saves credentials to a .env file. ' +
+      'Returns next_steps pointing to auth0_get_quickstart_guide tool to complete the integration.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        app_name: {
+          type: 'string',
+          description: 'Application name (defaults to "My App" if empty)',
+        },
+        framework: {
+          type: 'string',
+          enum: [...SUPPORTED_FRAMEWORKS],
+          description: 'JavaScript framework for the quickstart',
+        },
+        project_path: {
+          type: 'string',
+          description:
+            'Path to the project directory. Used for writing the .env file with Auth0 credentials.',
+        },
+      },
+      required: ['app_name', 'framework', 'project_path'],
+    },
+    _meta: {
+      requiredScopes: ['create:clients'],
+      localOnly: true,
+    },
+    annotations: {
+      title: 'Onboard Project',
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: false,
+      openWorldHint: false,
+    },
+  },
+];
+
+export const ONBOARDING_HANDLERS: Record<
+  string,
+  (request: HandlerRequest, config: HandlerConfig) => Promise<HandlerResponse>
+> = {
+  auth0_onboarding: async (
+    request: HandlerRequest,
+    config: HandlerConfig
+  ): Promise<HandlerResponse> => {
+    const { app_name: appName, framework, project_path: projectPath } = request.parameters;
+
+    // Validate framework
+    if (!framework) {
+      return createErrorResponse(
+        `Error: framework is required. Must be one of: ${SUPPORTED_FRAMEWORKS.join(', ')}`
+      );
+    }
+    if (!isFrameworkSupported(framework)) {
+      return createErrorResponse(
+        `Error: Unsupported framework "${framework}". Must be one of: ${SUPPORTED_FRAMEWORKS.join(', ')}`
+      );
+    }
+
+    // Validate project_path
+    if (!projectPath) {
+      return createErrorResponse('Error: project_path is required');
+    }
+    const resolvedProjectPath = path.resolve(projectPath);
+    if (resolvedProjectPath !== projectPath && projectPath.includes('..')) {
+      return createErrorResponse('Error: project_path must not contain path traversal sequences');
+    }
+    if (!fs.statSync(resolvedProjectPath, { throwIfNoEntry: false })?.isDirectory()) {
+      return createErrorResponse('Error: project_path must be an existing directory');
+    }
+
+    // Validate auth
+    if (!request.token) {
+      log('Warning: Token is empty or undefined');
+      return createErrorResponse('Error: Missing authorization token');
+    }
+    if (!config.domain) {
+      log('Error: Auth0 domain is not configured');
+      return createErrorResponse('Error: Auth0 domain is not configured');
+    }
+
+    // Fetch quickstart spec (fail before creating app)
+    const spec = await fetchQuickstartSpec(framework);
+    if (!spec) {
+      return createErrorResponse(
+        `Error: Quickstart definition unavailable for framework "${framework}". ` +
+          'The framework may not be supported or the CDN may be temporarily unavailable.'
+      );
+    }
+
+    // Map app_type from spec
+    const mappedAppType = APP_TYPE_MAP[spec.appType];
+    if (!mappedAppType) {
+      return createErrorResponse(
+        `Error: Unknown app type "${spec.appType}" in quickstart spec for framework "${framework}"`
+      );
+    }
+
+    // Derive token_endpoint_auth_method
+    const tokenEndpointAuthMethod =
+      mappedAppType === 'spa' || mappedAppType === 'native' ? 'none' : 'client_secret_post';
+
+    // Create application
+    const resolvedAppName = appName || 'My App';
+    const createResponse = await APPLICATION_HANDLERS['auth0_create_application'](
+      {
+        token: request.token,
+        parameters: {
+          name: resolvedAppName,
+          app_type: mappedAppType,
+          token_endpoint_auth_method: tokenEndpointAuthMethod,
+          oidc_conformant: true,
+        },
+      },
+      config
+    );
+
+    if (createResponse.isError) {
+      return createResponse;
+    }
+
+    // Parse create response to extract client_id
+    let appData: Record<string, any>;
+    try {
+      appData = JSON.parse(createResponse.content[0]?.text ?? '');
+    } catch {
+      return createErrorResponse('Error: Failed to parse application creation response');
+    }
+
+    const clientId = appData.client_id;
+    if (!clientId) {
+      return createErrorResponse('Error: Application created but client_id not found in response');
+    }
+
+    // Save credentials
+    const saveResponse = await APPLICATION_HANDLERS['auth0_save_credentials_to_file'](
+      {
+        token: request.token,
+        parameters: {
+          client_id: clientId,
+          framework,
+          project_path: resolvedProjectPath,
+        },
+      },
+      config
+    );
+
+    if (saveResponse.isError) {
+      return saveResponse;
+    }
+
+    // Parse save response
+    let saveData: Record<string, any>;
+    try {
+      saveData = JSON.parse(saveResponse.content[0]?.text ?? '');
+    } catch {
+      return createErrorResponse('Error: Failed to parse credentials save response');
+    }
+
+    return createSuccessResponse({
+      success: true,
+      client_id: clientId,
+      domain: config.domain,
+      app_type: mappedAppType,
+      framework,
+      credentials_saved_to: saveData.credentials_saved_to,
+      keys_written: saveData.keys_written,
+      next_steps: ['auth0_get_quickstart_guide'],
+    });
+  },
+};

--- a/src/tools/onboarding.ts
+++ b/src/tools/onboarding.ts
@@ -208,7 +208,9 @@ export const ONBOARDING_HANDLERS: Record<
         `Immediately call the auth0_get_quickstart_guide tool with ` +
         `client_id "${clientId}", framework "${framework}", and project_path "${resolvedProjectPath}" ` +
         `to perform the SDK integration. Do not wait for the user to ask, and do not tell the user ` +
-        `onboarding is complete until after auth0_get_quickstart_guide has finished.`,
+        `onboarding is complete until after auth0_get_quickstart_guide has finished. ` +
+        `Do NOT read, open, or echo any .env file (.env, .env.local, etc.) — it may hold unrelated ` +
+        `secrets, and the write already succeeded (see credentials_saved_to).`,
     });
   },
 };

--- a/test/exports.test.ts
+++ b/test/exports.test.ts
@@ -9,7 +9,11 @@ describe('exports', () => {
   });
 
   it('all other tools are not marked localOnly', () => {
-    const localOnlyToolNames = ['auth0_save_credentials_to_file', 'auth0_get_quickstart_guide'];
+    const localOnlyToolNames = [
+      'auth0_save_credentials_to_file',
+      'auth0_get_quickstart_guide',
+      'auth0_onboarding',
+    ];
     const localOnlyTools = TOOLS.filter(
       (t) => !localOnlyToolNames.includes(t.name) && t._meta?.localOnly
     );

--- a/test/tools/index.test.ts
+++ b/test/tools/index.test.ts
@@ -4,6 +4,7 @@ import { ACTION_TOOLS, ACTION_HANDLERS } from '../../src/tools/actions';
 import { APPLICATION_TOOLS, APPLICATION_HANDLERS } from '../../src/tools/applications';
 import { FORM_TOOLS, FORM_HANDLERS } from '../../src/tools/forms';
 import { LOG_TOOLS, LOG_HANDLERS } from '../../src/tools/logs';
+import { ONBOARDING_TOOLS, ONBOARDING_HANDLERS } from '../../src/tools/onboarding';
 import { QUICKSTART_TOOLS, QUICKSTART_HANDLERS } from '../../src/tools/quickstarts';
 import { RESOURCE_SERVER_TOOLS, RESOURCE_SERVER_HANDLERS } from '../../src/tools/resource-servers';
 import {
@@ -20,6 +21,7 @@ describe('Tools Index', () => {
         APPLICATION_TOOLS.length +
         FORM_TOOLS.length +
         LOG_TOOLS.length +
+        ONBOARDING_TOOLS.length +
         RESOURCE_SERVER_TOOLS.length +
         APPLICATION_GRANTS_TOOLS.length +
         QUICKSTART_TOOLS.length;
@@ -33,6 +35,7 @@ describe('Tools Index', () => {
         ...APPLICATION_TOOLS,
         ...FORM_TOOLS,
         ...LOG_TOOLS,
+        ...ONBOARDING_TOOLS,
         ...RESOURCE_SERVER_TOOLS,
         ...APPLICATION_GRANTS_TOOLS,
         ...QUICKSTART_TOOLS,
@@ -53,6 +56,7 @@ describe('Tools Index', () => {
       const applicationHandlerKeys = Object.keys(APPLICATION_HANDLERS);
       const formHandlerKeys = Object.keys(FORM_HANDLERS);
       const logHandlerKeys = Object.keys(LOG_HANDLERS);
+      const onboardingHandlerKeys = Object.keys(ONBOARDING_HANDLERS);
       const quickstartHandlerKeys = Object.keys(QUICKSTART_HANDLERS);
       const resourceServerHandlerKeys = Object.keys(RESOURCE_SERVER_HANDLERS);
       const applicationGrantsHandlerKey = Object.keys(APPLICATION_GRANTS_HANDLERS);
@@ -63,6 +67,7 @@ describe('Tools Index', () => {
         applicationHandlerKeys.length +
         formHandlerKeys.length +
         logHandlerKeys.length +
+        onboardingHandlerKeys.length +
         quickstartHandlerKeys.length +
         resourceServerHandlerKeys.length +
         applicationGrantsHandlerKey.length;
@@ -76,6 +81,7 @@ describe('Tools Index', () => {
         ...applicationHandlerKeys,
         ...formHandlerKeys,
         ...logHandlerKeys,
+        ...onboardingHandlerKeys,
         ...quickstartHandlerKeys,
         ...resourceServerHandlerKeys,
         ...applicationGrantsHandlerKey,
@@ -103,6 +109,10 @@ describe('Tools Index', () => {
       });
 
       resourceServerHandlerKeys.forEach((key) => {
+        expect(typeof HANDLERS[key]).toBe('function');
+      });
+
+      onboardingHandlerKeys.forEach((key) => {
         expect(typeof HANDLERS[key]).toBe('function');
       });
 

--- a/test/tools/onboarding.test.ts
+++ b/test/tools/onboarding.test.ts
@@ -396,7 +396,7 @@ describe('auth0_onboarding', () => {
       expect(response.content[0].text).toBe('Error: Unauthorized');
     });
 
-    it('should propagate save_credentials error', async () => {
+    it('should return error with client_id context when save_credentials fails', async () => {
       mockSaveCredentials.mockResolvedValue({
         isError: true,
         content: [{ type: 'text', text: 'Error: Permission denied' }],
@@ -414,7 +414,9 @@ describe('auth0_onboarding', () => {
         config
       );
       expect(response.isError).toBe(true);
-      expect(response.content[0].text).toBe('Error: Permission denied');
+      expect(response.content[0].text).toContain('client_id: new-client-id');
+      expect(response.content[0].text).toContain('credentials could not be saved');
+      expect(response.content[0].text).toContain('Permission denied');
     });
 
     it('should return error when create_application response is not valid JSON', async () => {
@@ -571,6 +573,42 @@ describe('auth0_onboarding', () => {
         expect.objectContaining({ token }),
         config
       );
+    });
+
+    it('should use resolved project_path when passing to save_credentials', async () => {
+      await ONBOARDING_HANDLERS.auth0_onboarding(
+        {
+          token,
+          parameters: {
+            app_name: 'My App',
+            framework: 'react',
+            project_path: '/tmp/./project',
+          },
+        },
+        config
+      );
+
+      expect(mockSaveCredentials).toHaveBeenCalledWith(
+        expect.objectContaining({
+          parameters: expect.objectContaining({ project_path: '/tmp/project' }),
+        }),
+        config
+      );
+    });
+
+    it('should accept framework in any case', async () => {
+      const response = await ONBOARDING_HANDLERS.auth0_onboarding(
+        {
+          token,
+          parameters: {
+            app_name: 'My App',
+            framework: 'React',
+            project_path: '/tmp/project',
+          },
+        },
+        config
+      );
+      expect(response.isError).toBe(false);
     });
   });
 });

--- a/test/tools/onboarding.test.ts
+++ b/test/tools/onboarding.test.ts
@@ -1,0 +1,576 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mockConfig } from '../mocks/config';
+
+vi.mock('../../src/utils/logger', () => ({
+  log: vi.fn(),
+}));
+
+const mockFetchQuickstartSpec = vi.fn();
+vi.mock('../../src/utils/quickstarts', () => ({
+  fetchQuickstartSpec: (...args: any[]) => mockFetchQuickstartSpec(...args),
+}));
+
+const mockStatSync = vi.fn();
+vi.mock('fs', () => ({
+  statSync: (...args: any[]) => mockStatSync(...args),
+}));
+
+const mockCreateApplication = vi.fn();
+const mockSaveCredentials = vi.fn();
+vi.mock('../../src/tools/applications', () => ({
+  APPLICATION_HANDLERS: {
+    auth0_create_application: (...args: any[]) => mockCreateApplication(...args),
+    auth0_save_credentials_to_file: (...args: any[]) => mockSaveCredentials(...args),
+  },
+}));
+
+const makeMockSpec = (overrides: Record<string, any> = {}) => ({
+  appType: 'spa',
+  defaultAppOrigin: { scheme: 'http', domain: 'localhost', port: 3000 },
+  callbackPath: '/callback',
+  logoutPath: '/',
+  llmPromptPath: 'assets/llm-prompts/react-llm-prompt.md',
+  llmPromptUrl:
+    'https://cdn.auth0.com/manhattan/quickstarts/versions/1.0.0/assets/prompts/en/react-prompt.md',
+  envSnippet: {
+    type: 'env',
+    language: 'shell',
+    fileName: '.env',
+    entries: [
+      { type: 'var', name: 'VITE_AUTH0_DOMAIN', value: '{yourDomain}' },
+      { type: 'var', name: 'VITE_AUTH0_CLIENT_ID', value: '{yourClientId}' },
+    ],
+  },
+  placeholders: {},
+  inputs: {},
+  environment: {},
+  ...overrides,
+});
+
+describe('auth0_onboarding', () => {
+  let ONBOARDING_HANDLERS: typeof import('../../src/tools/onboarding').ONBOARDING_HANDLERS;
+  let ONBOARDING_TOOLS: typeof import('../../src/tools/onboarding').ONBOARDING_TOOLS;
+
+  const domain = mockConfig.domain;
+  const token = mockConfig.token;
+  const config = { domain };
+
+  beforeEach(async () => {
+    vi.resetAllMocks();
+    mockFetchQuickstartSpec.mockResolvedValue(makeMockSpec());
+    mockStatSync.mockReturnValue({ isDirectory: () => true });
+
+    mockCreateApplication.mockResolvedValue({
+      isError: false,
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify({
+            client_id: 'new-client-id',
+            name: 'My App',
+            app_type: 'spa',
+          }),
+        },
+      ],
+    });
+
+    mockSaveCredentials.mockResolvedValue({
+      isError: false,
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify({
+            client_id: 'new-client-id',
+            credentials_saved_to: '/project/.env',
+            keys_written: ['VITE_AUTH0_DOMAIN', 'VITE_AUTH0_CLIENT_ID'],
+            file_created: true,
+            message: 'Credentials saved',
+          }),
+        },
+      ],
+    });
+
+    const mod = await import('../../src/tools/onboarding');
+    ONBOARDING_HANDLERS = mod.ONBOARDING_HANDLERS;
+    ONBOARDING_TOOLS = mod.ONBOARDING_TOOLS;
+  });
+
+  describe('tool metadata', () => {
+    it('should have correct annotations', () => {
+      const tool = ONBOARDING_TOOLS.find((t) => t.name === 'auth0_onboarding');
+      expect(tool?.annotations?.readOnlyHint).toBe(false);
+      expect(tool?.annotations?.destructiveHint).toBe(true);
+      expect(tool?.annotations?.idempotentHint).toBe(false);
+      expect(tool?.annotations?.openWorldHint).toBe(false);
+    });
+
+    it('should require create:clients scope and be localOnly', () => {
+      const tool = ONBOARDING_TOOLS.find((t) => t.name === 'auth0_onboarding');
+      expect(tool?._meta?.requiredScopes).toEqual(['create:clients']);
+      expect(tool?._meta?.localOnly).toBe(true);
+    });
+  });
+
+  describe('auth validation', () => {
+    it('should return error when token is missing', async () => {
+      const response = await ONBOARDING_HANDLERS.auth0_onboarding(
+        {
+          token: '',
+          parameters: {
+            app_name: 'My App',
+            framework: 'react',
+            project_path: '/tmp/project',
+          },
+        },
+        config
+      );
+      expect(response.isError).toBe(true);
+      expect(response.content[0].text).toContain('Missing authorization token');
+    });
+
+    it('should return error when domain is not configured', async () => {
+      const response = await ONBOARDING_HANDLERS.auth0_onboarding(
+        {
+          token,
+          parameters: {
+            app_name: 'My App',
+            framework: 'react',
+            project_path: '/tmp/project',
+          },
+        },
+        { domain: undefined }
+      );
+      expect(response.isError).toBe(true);
+      expect(response.content[0].text).toContain('Auth0 domain is not configured');
+    });
+  });
+
+  describe('input validation', () => {
+    it('should return error when framework is missing', async () => {
+      const response = await ONBOARDING_HANDLERS.auth0_onboarding(
+        { token, parameters: { app_name: 'My App', project_path: '/tmp/project' } },
+        config
+      );
+      expect(response.isError).toBe(true);
+      expect(response.content[0].text).toContain('framework is required');
+    });
+
+    it('should return error when framework is unsupported', async () => {
+      const response = await ONBOARDING_HANDLERS.auth0_onboarding(
+        {
+          token,
+          parameters: {
+            app_name: 'My App',
+            framework: 'svelte',
+            project_path: '/tmp/project',
+          },
+        },
+        config
+      );
+      expect(response.isError).toBe(true);
+      expect(response.content[0].text).toContain('Unsupported framework');
+      expect(response.content[0].text).toContain('svelte');
+    });
+
+    it('should return error when project_path is missing', async () => {
+      const response = await ONBOARDING_HANDLERS.auth0_onboarding(
+        { token, parameters: { app_name: 'My App', framework: 'react' } },
+        config
+      );
+      expect(response.isError).toBe(true);
+      expect(response.content[0].text).toContain('project_path is required');
+    });
+
+    it('should return error when project_path contains path traversal', async () => {
+      const response = await ONBOARDING_HANDLERS.auth0_onboarding(
+        {
+          token,
+          parameters: {
+            app_name: 'My App',
+            framework: 'react',
+            project_path: '/tmp/../etc/passwd',
+          },
+        },
+        config
+      );
+      expect(response.isError).toBe(true);
+      expect(response.content[0].text).toContain('path traversal');
+    });
+
+    it('should return error when project_path is not a directory', async () => {
+      mockStatSync.mockReturnValue({ isDirectory: () => false });
+
+      const response = await ONBOARDING_HANDLERS.auth0_onboarding(
+        {
+          token,
+          parameters: {
+            app_name: 'My App',
+            framework: 'react',
+            project_path: '/tmp/project',
+          },
+        },
+        config
+      );
+      expect(response.isError).toBe(true);
+      expect(response.content[0].text).toContain('existing directory');
+    });
+
+    it('should return error when project_path does not exist', async () => {
+      mockStatSync.mockReturnValue(undefined);
+
+      const response = await ONBOARDING_HANDLERS.auth0_onboarding(
+        {
+          token,
+          parameters: {
+            app_name: 'My App',
+            framework: 'react',
+            project_path: '/tmp/project',
+          },
+        },
+        config
+      );
+      expect(response.isError).toBe(true);
+      expect(response.content[0].text).toContain('existing directory');
+    });
+  });
+
+  describe('quickstart spec resolution', () => {
+    it('should return error when spec is unavailable', async () => {
+      mockFetchQuickstartSpec.mockResolvedValue(null);
+
+      const response = await ONBOARDING_HANDLERS.auth0_onboarding(
+        {
+          token,
+          parameters: {
+            app_name: 'My App',
+            framework: 'react',
+            project_path: '/tmp/project',
+          },
+        },
+        config
+      );
+      expect(response.isError).toBe(true);
+      expect(response.content[0].text).toContain('definition unavailable');
+      expect(response.content[0].text).toContain('react');
+    });
+
+    it('should not call create_application when spec is unavailable', async () => {
+      mockFetchQuickstartSpec.mockResolvedValue(null);
+
+      await ONBOARDING_HANDLERS.auth0_onboarding(
+        {
+          token,
+          parameters: {
+            app_name: 'My App',
+            framework: 'react',
+            project_path: '/tmp/project',
+          },
+        },
+        config
+      );
+      expect(mockCreateApplication).not.toHaveBeenCalled();
+    });
+
+    it('should return error for unknown app type in spec', async () => {
+      mockFetchQuickstartSpec.mockResolvedValue(makeMockSpec({ appType: 'unknown' }));
+
+      const response = await ONBOARDING_HANDLERS.auth0_onboarding(
+        {
+          token,
+          parameters: {
+            app_name: 'My App',
+            framework: 'react',
+            project_path: '/tmp/project',
+          },
+        },
+        config
+      );
+      expect(response.isError).toBe(true);
+      expect(response.content[0].text).toContain('Unknown app type');
+      expect(response.content[0].text).toContain('unknown');
+    });
+  });
+
+  describe('app type mapping', () => {
+    it('should map spa appType to spa with token_endpoint_auth_method none', async () => {
+      mockFetchQuickstartSpec.mockResolvedValue(makeMockSpec({ appType: 'spa' }));
+
+      await ONBOARDING_HANDLERS.auth0_onboarding(
+        {
+          token,
+          parameters: {
+            app_name: 'My App',
+            framework: 'react',
+            project_path: '/tmp/project',
+          },
+        },
+        config
+      );
+
+      expect(mockCreateApplication).toHaveBeenCalledWith(
+        expect.objectContaining({
+          parameters: expect.objectContaining({
+            app_type: 'spa',
+            token_endpoint_auth_method: 'none',
+            oidc_conformant: true,
+          }),
+        }),
+        config
+      );
+    });
+
+    it('should map webapp appType to regular_web with client_secret_post', async () => {
+      mockFetchQuickstartSpec.mockResolvedValue(makeMockSpec({ appType: 'webapp' }));
+
+      await ONBOARDING_HANDLERS.auth0_onboarding(
+        {
+          token,
+          parameters: {
+            app_name: 'My App',
+            framework: 'nextjs',
+            project_path: '/tmp/project',
+          },
+        },
+        config
+      );
+
+      expect(mockCreateApplication).toHaveBeenCalledWith(
+        expect.objectContaining({
+          parameters: expect.objectContaining({
+            app_type: 'regular_web',
+            token_endpoint_auth_method: 'client_secret_post',
+            oidc_conformant: true,
+          }),
+        }),
+        config
+      );
+    });
+
+    it('should map native appType to native with token_endpoint_auth_method none', async () => {
+      mockFetchQuickstartSpec.mockResolvedValue(makeMockSpec({ appType: 'native' }));
+
+      await ONBOARDING_HANDLERS.auth0_onboarding(
+        {
+          token,
+          parameters: {
+            app_name: 'My App',
+            framework: 'react',
+            project_path: '/tmp/project',
+          },
+        },
+        config
+      );
+
+      expect(mockCreateApplication).toHaveBeenCalledWith(
+        expect.objectContaining({
+          parameters: expect.objectContaining({
+            app_type: 'native',
+            token_endpoint_auth_method: 'none',
+            oidc_conformant: true,
+          }),
+        }),
+        config
+      );
+    });
+  });
+
+  describe('handler chaining errors', () => {
+    it('should propagate create_application error', async () => {
+      mockCreateApplication.mockResolvedValue({
+        isError: true,
+        content: [{ type: 'text', text: 'Error: Unauthorized' }],
+      });
+
+      const response = await ONBOARDING_HANDLERS.auth0_onboarding(
+        {
+          token,
+          parameters: {
+            app_name: 'My App',
+            framework: 'react',
+            project_path: '/tmp/project',
+          },
+        },
+        config
+      );
+      expect(response.isError).toBe(true);
+      expect(response.content[0].text).toBe('Error: Unauthorized');
+    });
+
+    it('should propagate save_credentials error', async () => {
+      mockSaveCredentials.mockResolvedValue({
+        isError: true,
+        content: [{ type: 'text', text: 'Error: Permission denied' }],
+      });
+
+      const response = await ONBOARDING_HANDLERS.auth0_onboarding(
+        {
+          token,
+          parameters: {
+            app_name: 'My App',
+            framework: 'react',
+            project_path: '/tmp/project',
+          },
+        },
+        config
+      );
+      expect(response.isError).toBe(true);
+      expect(response.content[0].text).toBe('Error: Permission denied');
+    });
+
+    it('should return error when create_application response is not valid JSON', async () => {
+      mockCreateApplication.mockResolvedValue({
+        isError: false,
+        content: [{ type: 'text', text: 'not json' }],
+      });
+
+      const response = await ONBOARDING_HANDLERS.auth0_onboarding(
+        {
+          token,
+          parameters: {
+            app_name: 'My App',
+            framework: 'react',
+            project_path: '/tmp/project',
+          },
+        },
+        config
+      );
+      expect(response.isError).toBe(true);
+      expect(response.content[0].text).toContain('Failed to parse application creation response');
+    });
+
+    it('should return error when create_application response has no client_id', async () => {
+      mockCreateApplication.mockResolvedValue({
+        isError: false,
+        content: [{ type: 'text', text: JSON.stringify({ name: 'My App' }) }],
+      });
+
+      const response = await ONBOARDING_HANDLERS.auth0_onboarding(
+        {
+          token,
+          parameters: {
+            app_name: 'My App',
+            framework: 'react',
+            project_path: '/tmp/project',
+          },
+        },
+        config
+      );
+      expect(response.isError).toBe(true);
+      expect(response.content[0].text).toContain('client_id not found');
+    });
+
+    it('should return error when save_credentials response is not valid JSON', async () => {
+      mockSaveCredentials.mockResolvedValue({
+        isError: false,
+        content: [{ type: 'text', text: 'not json' }],
+      });
+
+      const response = await ONBOARDING_HANDLERS.auth0_onboarding(
+        {
+          token,
+          parameters: {
+            app_name: 'My App',
+            framework: 'react',
+            project_path: '/tmp/project',
+          },
+        },
+        config
+      );
+      expect(response.isError).toBe(true);
+      expect(response.content[0].text).toContain('Failed to parse credentials save response');
+    });
+  });
+
+  describe('success flow', () => {
+    it('should return success with all required fields', async () => {
+      const response = await ONBOARDING_HANDLERS.auth0_onboarding(
+        {
+          token,
+          parameters: {
+            app_name: 'My App',
+            framework: 'react',
+            project_path: '/tmp/project',
+          },
+        },
+        config
+      );
+
+      expect(response.isError).toBe(false);
+      const data = JSON.parse(response.content[0].text);
+      expect(data.success).toBe(true);
+      expect(data.client_id).toBe('new-client-id');
+      expect(data.domain).toBe(domain);
+      expect(data.app_type).toBe('spa');
+      expect(data.framework).toBe('react');
+      expect(data.credentials_saved_to).toBe('/project/.env');
+      expect(data.keys_written).toEqual(['VITE_AUTH0_DOMAIN', 'VITE_AUTH0_CLIENT_ID']);
+      expect(data.next_steps).toEqual(['auth0_get_quickstart_guide']);
+    });
+
+    it('should default app_name to "My App" when empty', async () => {
+      await ONBOARDING_HANDLERS.auth0_onboarding(
+        {
+          token,
+          parameters: {
+            app_name: '',
+            framework: 'react',
+            project_path: '/tmp/project',
+          },
+        },
+        config
+      );
+
+      expect(mockCreateApplication).toHaveBeenCalledWith(
+        expect.objectContaining({
+          parameters: expect.objectContaining({ name: 'My App' }),
+        }),
+        config
+      );
+    });
+
+    it('should pass correct parameters to save_credentials', async () => {
+      await ONBOARDING_HANDLERS.auth0_onboarding(
+        {
+          token,
+          parameters: {
+            app_name: 'My App',
+            framework: 'react',
+            project_path: '/tmp/project',
+          },
+        },
+        config
+      );
+
+      expect(mockSaveCredentials).toHaveBeenCalledWith(
+        expect.objectContaining({
+          token,
+          parameters: expect.objectContaining({
+            client_id: 'new-client-id',
+            framework: 'react',
+            project_path: '/tmp/project',
+          }),
+        }),
+        config
+      );
+    });
+
+    it('should pass the token to create_application', async () => {
+      await ONBOARDING_HANDLERS.auth0_onboarding(
+        {
+          token,
+          parameters: {
+            app_name: 'Test',
+            framework: 'vue',
+            project_path: '/tmp/project',
+          },
+        },
+        config
+      );
+
+      expect(mockCreateApplication).toHaveBeenCalledWith(
+        expect.objectContaining({ token }),
+        config
+      );
+    });
+  });
+});

--- a/test/tools/onboarding.test.ts
+++ b/test/tools/onboarding.test.ts
@@ -101,7 +101,7 @@ describe('auth0_onboarding', () => {
       expect(tool?.annotations?.readOnlyHint).toBe(false);
       expect(tool?.annotations?.destructiveHint).toBe(true);
       expect(tool?.annotations?.idempotentHint).toBe(false);
-      expect(tool?.annotations?.openWorldHint).toBe(false);
+      expect(tool?.annotations?.openWorldHint).toBe(true);
     });
 
     it('should require create:clients scope and be localOnly', () => {

--- a/test/tools/onboarding.test.ts
+++ b/test/tools/onboarding.test.ts
@@ -507,6 +507,71 @@ describe('auth0_onboarding', () => {
       expect(data.credentials_saved_to).toBe('/project/.env');
       expect(data.keys_written).toEqual(['VITE_AUTH0_DOMAIN', 'VITE_AUTH0_CLIENT_ID']);
       expect(data.next_steps).toEqual(['auth0_get_quickstart_guide']);
+      expect(data.instructions).toContain('auth0_get_quickstart_guide');
+      expect(data.instructions).toContain('onboarding is not yet complete');
+    });
+
+    it('should propagate _credentials_access and skip prompt flag from the create response', async () => {
+      mockCreateApplication.mockResolvedValue({
+        isError: false,
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify({
+              client_id: 'new-client-id',
+              name: 'My App',
+              app_type: 'regular_web',
+              client_secret: '[REDACTED]',
+              skip_non_verifiable_callback_uri_confirmation_prompt: true,
+              _credentials_access: {
+                note: 'Credentials are masked for security',
+                how_to_access: ['View in Auth0 Dashboard: https://manage.auth0.com/...'],
+              },
+            }),
+          },
+        ],
+      });
+
+      const response = await ONBOARDING_HANDLERS.auth0_onboarding(
+        {
+          token,
+          parameters: {
+            app_name: 'My App',
+            framework: 'nextjs',
+            project_path: '/tmp/project',
+          },
+        },
+        config
+      );
+
+      expect(response.isError).toBe(false);
+      const data = JSON.parse(response.content[0].text);
+      expect(data._credentials_access).toBeDefined();
+      expect(data._credentials_access.how_to_access).toBeDefined();
+      expect(data.skip_non_verifiable_callback_uri_confirmation_prompt).toBe(true);
+      expect(data.instructions).toContain('client_secret is redacted');
+      expect(data.instructions).toContain(
+        'skip_non_verifiable_callback_uri_confirmation_prompt was automatically enabled'
+      );
+    });
+
+    it('should not include credential/skip notes when the create response omits them', async () => {
+      const response = await ONBOARDING_HANDLERS.auth0_onboarding(
+        {
+          token,
+          parameters: {
+            app_name: 'My App',
+            framework: 'react',
+            project_path: '/tmp/project',
+          },
+        },
+        config
+      );
+
+      const data = JSON.parse(response.content[0].text);
+      expect(data._credentials_access).toBeUndefined();
+      expect(data.skip_non_verifiable_callback_uri_confirmation_prompt).toBeUndefined();
+      expect(data.instructions).not.toContain('client_secret is redacted');
     });
 
     it('should default app_name to "My App" when empty', async () => {


### PR DESCRIPTION
### Changes

Adds the `auth0_onboarding` MCP tool, a single-call entry point that creates an Auth0 application for a given framework, saves its credentials to the project, and hands off to the quickstart guide.

- **New tool `auth0_onboarding`** (`src/tools/onboarding.ts`): given `app_name`, `framework`, and `project_path`, it:
  - Validates the framework against the shared `SUPPORTED_FRAMEWORKS` / `isFrameworkSupported` and validates `project_path` (existing directory, no path traversal).
  - Fetches the quickstart spec *before* creating anything, so an unsupported framework or CDN outage fails without side effects.
  - Maps the spec `appType` to an Auth0 `app_type` (`spa` → `spa`, `webapp` → `regular_web`, `native` → `native`) and derives `token_endpoint_auth_method` (`none` for SPA/native, `client_secret_post` otherwise), creating the app as `oidc_conformant`.
  - Delegates to `auth0_create_application` then `auth0_save_credentials_to_file`, returning a clear error (including the created `client_id`) if the credential save fails after the app was created.
  - Returns `next_steps: ['auth0_get_quickstart_guide']` with instructions framing onboarding as a two-step flow, surfacing credential-access and `skip_non_verifiable_callback_uri_confirmation_prompt` notes when present, and explicitly instructing the agent not to read/echo any `.env` file.
- Requires the `create:clients` scope; marked `localOnly`, `destructiveHint: true`, `idempotentHint: false`.
- Registered the tool in `src/tools/index.ts`.

### References

- https://auth0team.atlassian.net/browse/DXAA-430

### Testing
mcp-api e2e tests pass
<img width="1642" height="1055" alt="Screenshot 2026-06-11 at 1 12 10 PM" src="https://github.com/user-attachments/assets/ba400905-6dde-4ac0-ad45-5fad2e367fc0" />

Unit tests in `test/tools/onboarding.test.ts` cover framework validation (missing, unsupported, mixed-case), `project_path` validation, auth/domain checks, spec-unavailable and unknown-app-type handling, app-type mapping and auth-method derivation, the create → save delegation (including save-after-create failure), and the `next_steps`/instructions payload (credential-access and skip-prompt notes).

Run: `npx vitest run test/tools/onboarding.test.ts`

- [x] This change adds unit test coverage
- [ ] This change adds integration test coverage

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors