### PR TITLE
Fix: Undocumented Parameters Hardening

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -88,9 +88,27 @@ export async function startServer(options?: ServerOptions) {
 
       try {
         // Check available (filtered) tools, not all handlers
-        const isToolAvailable = availableTools.some((t) => t.name === toolName);
-        if (!isToolAvailable || !HANDLERS[toolName]) {
+        const tool = availableTools.find((t) => t.name === toolName);
+        if (!tool || !HANDLERS[toolName]) {
           throw new Error(`Unknown or restricted tool: ${toolName}`);
+        }
+
+        // Reject any argument not declared in the tool's inputSchema.
+        // MCP clients only surface schema-declared parameters for human approval,
+        // so forwarding undeclared parameters to the Auth0 Management API would let
+        // a prompt-injection attacker smuggle security-critical fields (e.g.
+        // custom_login_page, addons, client_authentication_methods) past the
+        // human-in-the-loop confirmation. Enforcing the schema as an allowlist
+        // closes that LLM-to-tool trust boundary gap.
+        const declaredParameters = tool.inputSchema?.properties;
+        if (declaredParameters) {
+          const allowedKeys = new Set(Object.keys(declaredParameters));
+          const undeclaredKeys = Object.keys(request.params.arguments || {}).filter(
+            (key) => !allowedKeys.has(key)
+          );
+          if (undeclaredKeys.length > 0) {
+            throw new Error(`Rejected undeclared parameters: ${undeclaredKeys.join(', ')}`);
+          }
         }
 
         // Check if config is still valid, reload if needed

--- a/src/tools/applications.ts
+++ b/src/tools/applications.ts
@@ -17,7 +17,6 @@ import type {
   ClientCreateAppTypeEnum,
   ClientCreateOrganizationUsageEnum,
   ClientCreateOrganizationRequireBehaviorEnum,
-  ClientCreateComplianceLevelEnum,
   ClientCreate,
   ClientUpdate,
 } from 'auth0';
@@ -147,6 +146,49 @@ export const APPLICATION_TOOLS: Tool[] = [
             'Token endpoint authentication method. When creating, defaults based on app_type: "none" for SPA/Native (public clients), "client_secret_post" for Regular Web/M2M (confidential clients).',
           enum: ['none', 'client_secret_post', 'client_secret_basic'],
         },
+        grant_types: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'List of grant types for this client',
+        },
+        jwt_configuration: {
+          type: 'object',
+          description: 'JWT configuration settings',
+        },
+        refresh_token: {
+          type: 'object',
+          description: 'Refresh token configuration',
+        },
+        mobile: {
+          type: 'object',
+          description: 'Mobile app configuration settings',
+        },
+        web_origins: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'URLs allowed to make cross-origin (CORS) requests to Auth0 from JavaScript.',
+        },
+        client_aliases: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'List of audiences or client identifiers used for SAML or delegation.',
+        },
+        cross_origin_loc: {
+          type: 'string',
+          description: 'URL of the location in your site where the cross-origin verification takes place for cross-origin authentication.',
+        },
+        oidc_logout: {
+          type: 'object',
+          description: 'Configuration for OIDC back-channel logout.',
+        },
+        sso: {
+          type: 'boolean',
+          description: 'Whether Single Sign On is enabled for this client.',
+        },
+        native_social_login: {
+          type: 'object',
+          description: 'Configuration for native social login (e.g. Apple, Facebook).',
+        },
       },
       required: ['name'],
     },
@@ -257,6 +299,32 @@ export const APPLICATION_TOOLS: Tool[] = [
         mobile: {
           type: 'object',
           description: 'Mobile app configuration settings',
+        },
+        web_origins: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'URLs allowed to make cross-origin (CORS) requests to Auth0 from JavaScript.',
+        },
+        client_aliases: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'List of audiences or client identifiers used for SAML or delegation.',
+        },
+        cross_origin_loc: {
+          type: 'string',
+          description: 'URL of the location in your site where the cross-origin verification takes place for cross-origin authentication.',
+        },
+        oidc_logout: {
+          type: 'object',
+          description: 'Configuration for OIDC back-channel logout.',
+        },
+        sso: {
+          type: 'boolean',
+          description: 'Whether Single Sign On is enabled for this client.',
+        },
+        native_social_login: {
+          type: 'object',
+          description: 'Configuration for native social login (e.g. Apple, Facebook).',
         },
         skip_non_verifiable_callback_uri_confirmation_prompt: {
           type: 'boolean',
@@ -555,28 +623,15 @@ export const APPLICATION_HANDLERS: Record<
         is_first_party,
         oidc_conformant,
         jwt_configuration,
-        encryption_key,
         sso,
         cross_origin_authentication,
         cross_origin_loc,
         sso_disabled,
-        custom_login_page_on,
-        custom_login_page,
-        custom_login_page_preview,
-        form_template,
-        addons,
-        client_metadata,
         mobile,
-        initiate_login_uri,
         native_social_login,
         refresh_token,
         organization_usage,
         organization_require_behavior,
-        client_authentication_methods,
-        require_pushed_authorization_requests,
-        signed_request_object,
-        require_proof_of_possession,
-        compliance_level,
       } = request.parameters;
 
       if (!name) {
@@ -625,22 +680,12 @@ export const APPLICATION_HANDLERS: Record<
       if (is_first_party !== undefined) clientData.is_first_party = is_first_party;
       if (oidc_conformant !== undefined) clientData.oidc_conformant = oidc_conformant;
       if (jwt_configuration !== undefined) clientData.jwt_configuration = jwt_configuration;
-      if (encryption_key !== undefined) clientData.encryption_key = encryption_key;
       if (sso !== undefined) clientData.sso = sso;
       if (cross_origin_authentication !== undefined)
         clientData.cross_origin_authentication = cross_origin_authentication;
       if (cross_origin_loc !== undefined) clientData.cross_origin_loc = cross_origin_loc;
       if (sso_disabled !== undefined) clientData.sso_disabled = sso_disabled;
-      if (custom_login_page_on !== undefined)
-        clientData.custom_login_page_on = custom_login_page_on;
-      if (custom_login_page !== undefined) clientData.custom_login_page = custom_login_page;
-      if (custom_login_page_preview !== undefined)
-        clientData.custom_login_page_preview = custom_login_page_preview;
-      if (form_template !== undefined) clientData.form_template = form_template;
-      if (addons !== undefined) clientData.addons = addons;
-      if (client_metadata !== undefined) clientData.client_metadata = client_metadata;
       if (mobile !== undefined) clientData.mobile = mobile;
-      if (initiate_login_uri !== undefined) clientData.initiate_login_uri = initiate_login_uri;
       if (native_social_login !== undefined) clientData.native_social_login = native_social_login;
       if (refresh_token !== undefined) clientData.refresh_token = refresh_token;
       if (organization_usage !== undefined)
@@ -648,16 +693,6 @@ export const APPLICATION_HANDLERS: Record<
       if (organization_require_behavior !== undefined)
         clientData.organization_require_behavior =
           organization_require_behavior as ClientCreateOrganizationRequireBehaviorEnum;
-      if (client_authentication_methods !== undefined)
-        clientData.client_authentication_methods = client_authentication_methods;
-      if (require_pushed_authorization_requests !== undefined)
-        clientData.require_pushed_authorization_requests = require_pushed_authorization_requests;
-      if (signed_request_object !== undefined)
-        clientData.signed_request_object = signed_request_object;
-      if (require_proof_of_possession !== undefined)
-        clientData.require_proof_of_possession = require_proof_of_possession;
-      if (compliance_level !== undefined)
-        clientData.compliance_level = compliance_level as ClientCreateComplianceLevelEnum;
       if (callbacks && hasNonVerifiableCallbacks(callbacks)) {
         clientData.skip_non_verifiable_callback_uri_confirmation_prompt = true;
       }
@@ -764,28 +799,15 @@ export const APPLICATION_HANDLERS: Record<
         is_first_party,
         oidc_conformant,
         jwt_configuration,
-        encryption_key,
         sso,
         cross_origin_authentication,
         cross_origin_loc,
         sso_disabled,
-        custom_login_page_on,
-        custom_login_page,
-        custom_login_page_preview,
-        form_template,
-        addons,
-        client_metadata,
         mobile,
-        initiate_login_uri,
         native_social_login,
         refresh_token,
         organization_usage,
         organization_require_behavior,
-        client_authentication_methods,
-        require_pushed_authorization_requests,
-        signed_request_object,
-        require_proof_of_possession,
-        compliance_level,
         skip_non_verifiable_callback_uri_confirmation_prompt,
       } = request.parameters;
 
@@ -809,22 +831,12 @@ export const APPLICATION_HANDLERS: Record<
       if (is_first_party !== undefined) updateData.is_first_party = is_first_party;
       if (oidc_conformant !== undefined) updateData.oidc_conformant = oidc_conformant;
       if (jwt_configuration !== undefined) updateData.jwt_configuration = jwt_configuration;
-      if (encryption_key !== undefined) updateData.encryption_key = encryption_key;
       if (sso !== undefined) updateData.sso = sso;
       if (cross_origin_authentication !== undefined)
         updateData.cross_origin_authentication = cross_origin_authentication;
       if (cross_origin_loc !== undefined) updateData.cross_origin_loc = cross_origin_loc;
       if (sso_disabled !== undefined) updateData.sso_disabled = sso_disabled;
-      if (custom_login_page_on !== undefined)
-        updateData.custom_login_page_on = custom_login_page_on;
-      if (custom_login_page !== undefined) updateData.custom_login_page = custom_login_page;
-      if (custom_login_page_preview !== undefined)
-        updateData.custom_login_page_preview = custom_login_page_preview;
-      if (form_template !== undefined) updateData.form_template = form_template;
-      if (addons !== undefined) updateData.addons = addons;
-      if (client_metadata !== undefined) updateData.client_metadata = client_metadata;
       if (mobile !== undefined) updateData.mobile = mobile;
-      if (initiate_login_uri !== undefined) updateData.initiate_login_uri = initiate_login_uri;
       if (native_social_login !== undefined) updateData.native_social_login = native_social_login;
       if (refresh_token !== undefined) updateData.refresh_token = refresh_token;
       if (organization_usage !== undefined)
@@ -832,16 +844,6 @@ export const APPLICATION_HANDLERS: Record<
       if (organization_require_behavior !== undefined)
         updateData.organization_require_behavior =
           organization_require_behavior as ClientCreateOrganizationRequireBehaviorEnum;
-      if (client_authentication_methods !== undefined)
-        updateData.client_authentication_methods = client_authentication_methods;
-      if (require_pushed_authorization_requests !== undefined)
-        updateData.require_pushed_authorization_requests = require_pushed_authorization_requests;
-      if (signed_request_object !== undefined)
-        updateData.signed_request_object = signed_request_object;
-      if (require_proof_of_possession !== undefined)
-        updateData.require_proof_of_possession = require_proof_of_possession;
-      if (compliance_level !== undefined)
-        updateData.compliance_level = compliance_level as ClientCreateComplianceLevelEnum;
       if (skip_non_verifiable_callback_uri_confirmation_prompt !== undefined)
         updateData.skip_non_verifiable_callback_uri_confirmation_prompt =
           skip_non_verifiable_callback_uri_confirmation_prompt;

--- a/src/tools/resource-servers.ts
+++ b/src/tools/resource-servers.ts
@@ -123,6 +123,10 @@ export const RESOURCE_SERVER_TOOLS: Tool[] = [
           type: 'boolean',
           description: 'Whether to enforce authorization policies.',
         },
+        client: {
+          type: 'object',
+          description: 'Client-related configuration for the resource server.',
+        },
         token_encryption: {
           type: 'object',
           description: 'Token encryption configuration.',
@@ -217,6 +221,10 @@ export const RESOURCE_SERVER_TOOLS: Tool[] = [
         enforce_policies: {
           type: 'boolean',
           description: 'Whether to enforce authorization policies.',
+        },
+        client: {
+          type: 'object',
+          description: 'Client-related configuration for the resource server.',
         },
         token_encryption: {
           type: 'object',

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -64,9 +64,27 @@ vi.mock('../src/tools/index.js', () => {
   });
 
   return {
-    TOOLS: [{ name: 'test_tool', description: 'Test tool', inputSchema: {} }],
+    TOOLS: [
+      { name: 'test_tool', description: 'Test tool', inputSchema: {} },
+      {
+        name: 'schema_tool',
+        description: 'Tool with a declared input schema',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            name: { type: 'string' },
+            client_id: { type: 'string' },
+          },
+          required: ['name'],
+        },
+      },
+    ],
     HANDLERS: {
       test_tool: mockHandler,
+      schema_tool: vi.fn().mockResolvedValue({
+        content: [{ type: 'text', text: 'Success' }],
+        isError: false,
+      }),
     },
   };
 });
@@ -334,6 +352,79 @@ describe('Server', () => {
       // Verify the error response
       expect(result).toHaveProperty('isError', true);
       expect(result.content[0].text).toContain('Error: Tool execution failed');
+    });
+
+    it('should reject arguments not declared in the tool inputSchema', async () => {
+      await startServer();
+
+      const handlerFn = getCallToolHandler();
+
+      // custom_login_page is a security-critical Auth0 param that is NOT declared
+      // in schema_tool's inputSchema, so it must be rejected before reaching the handler.
+      const request = {
+        params: {
+          name: 'schema_tool',
+          arguments: {
+            name: 'My App',
+            custom_login_page_on: true,
+            custom_login_page: '<script>steal()</script>',
+          },
+        },
+      };
+
+      const result = await handlerFn(request);
+
+      expect(result).toHaveProperty('isError', true);
+      expect(result.content[0].text).toContain('Rejected undeclared parameters');
+      expect(result.content[0].text).toContain('custom_login_page_on');
+      expect(result.content[0].text).toContain('custom_login_page');
+      expect(HANDLERS.schema_tool).not.toHaveBeenCalled();
+    });
+
+    it('should allow arguments that are all declared in the tool inputSchema', async () => {
+      await startServer();
+
+      const handlerFn = getCallToolHandler();
+
+      const request = {
+        params: {
+          name: 'schema_tool',
+          arguments: {
+            name: 'My App',
+            client_id: 'abc123',
+          },
+        },
+      };
+
+      const result = await handlerFn(request);
+
+      expect(result).toHaveProperty('isError', false);
+      expect(HANDLERS.schema_tool).toHaveBeenCalledWith(
+        {
+          token: mockConfig.token,
+          parameters: { name: 'My App', client_id: 'abc123' },
+        },
+        { domain: mockConfig.domain }
+      );
+    });
+
+    it('should not enforce an allowlist when the tool declares no schema properties', async () => {
+      await startServer();
+
+      const handlerFn = getCallToolHandler();
+
+      // test_tool has an empty inputSchema (no properties), so validation is skipped.
+      const request = {
+        params: {
+          name: 'test_tool',
+          arguments: { anything: 'goes' },
+        },
+      };
+
+      const result = await handlerFn(request);
+
+      expect(result).toHaveProperty('isError', false);
+      expect(HANDLERS.test_tool).toHaveBeenCalled();
     });
   });
 });

--- a/test/tools/applications.test.ts
+++ b/test/tools/applications.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { http, HttpResponse } from 'msw';
-import { APPLICATION_HANDLERS } from '../../src/tools/applications';
+import { APPLICATION_HANDLERS, APPLICATION_TOOLS } from '../../src/tools/applications';
 import { ServerMode } from '../../src/utils/types';
 import { mockConfig } from '../mocks/config';
 import { mockApplications } from '../mocks/auth0/applications';
@@ -510,6 +510,71 @@ describe('Applications Tool Handlers', () => {
         }
       });
     });
+
+    describe('parameter hardening', () => {
+      const createTool = APPLICATION_TOOLS.find((t) => t.name === 'auth0_create_application');
+      const declaredParams = Object.keys(createTool?.inputSchema?.properties ?? {});
+
+      async function captureBody(parameters: Record<string, any>) {
+        let capturedBody: Record<string, any> | undefined;
+        server.use(
+          http.post('https://*/api/v2/clients', async ({ request }) => {
+            capturedBody = (await request.json()) as Record<string, any>;
+            return HttpResponse.json({ ...capturedBody, client_id: 'test-app-id' });
+          })
+        );
+
+        const response = await APPLICATION_HANDLERS.auth0_create_application(
+          { token, parameters },
+          { domain }
+        );
+
+        expect(response.isError).toBe(false);
+        expect(capturedBody).toBeDefined();
+        return capturedBody!;
+      }
+
+      it('should not forward parameters that are not declared in the inputSchema', async () => {
+        // Undeclared fields (e.g. arriving via prompt injection) must never reach
+        // the Auth0 API, regardless of which specific fields they are.
+        const undeclared = {
+          custom_login_page: '<script>steal()</script>',
+          encryption_key: 'injected',
+          addons: { samlp: {} },
+          compliance_level: 'fapi',
+          some_future_unsupported_field: 'injected',
+        };
+
+        const capturedBody = await captureBody({ name: 'Test App', app_type: 'spa', ...undeclared });
+
+        for (const key of Object.keys(capturedBody)) {
+          expect(declaredParams).toContain(key);
+        }
+        for (const key of Object.keys(undeclared)) {
+          expect(capturedBody[key]).toBeUndefined();
+        }
+      });
+
+      it('should forward declared configuration parameters to the Auth0 API', async () => {
+        const declared = {
+          web_origins: ['https://example.com'],
+          client_aliases: ['urn:example'],
+          cross_origin_loc: 'https://example.com/cross-origin',
+          oidc_logout: { backchannel_logout_urls: ['https://example.com/logout'] },
+          sso: true,
+          native_social_login: { apple: { enabled: true } },
+          grant_types: ['authorization_code'],
+          mobile: { ios: { team_id: 'TEAM' } },
+          refresh_token: { rotation_type: 'rotating' },
+        };
+
+        const capturedBody = await captureBody({ name: 'Test App', app_type: 'spa', ...declared });
+
+        for (const [key, value] of Object.entries(declared)) {
+          expect(capturedBody[key]).toEqual(value);
+        }
+      });
+    });
   });
 
   describe('auth0_update_application', () => {
@@ -661,6 +726,71 @@ describe('Applications Tool Handlers', () => {
 
       expect(response.isError).toBe(false);
       expect(capturedBody.skip_non_verifiable_callback_uri_confirmation_prompt).toBe(false);
+    });
+
+    describe('parameter hardening', () => {
+      const updateTool = APPLICATION_TOOLS.find((t) => t.name === 'auth0_update_application');
+      const declaredParams = Object.keys(updateTool?.inputSchema?.properties ?? {});
+
+      async function captureBody(parameters: Record<string, any>) {
+        const clientId = mockApplications[0].client_id;
+        let capturedBody: Record<string, any> | undefined;
+        server.use(
+          http.patch(`https://*/api/v2/clients/${clientId}`, async ({ request }) => {
+            capturedBody = (await request.json()) as Record<string, any>;
+            return HttpResponse.json({ ...mockApplications[0], ...capturedBody });
+          })
+        );
+
+        const response = await APPLICATION_HANDLERS.auth0_update_application(
+          { token, parameters: { client_id: clientId, ...parameters } },
+          { domain }
+        );
+
+        expect(response.isError).toBe(false);
+        expect(capturedBody).toBeDefined();
+        return capturedBody!;
+      }
+
+      it('should not forward parameters that are not declared in the inputSchema', async () => {
+        const undeclared = {
+          custom_login_page: '<script>steal()</script>',
+          encryption_key: 'injected',
+          addons: { samlp: {} },
+          compliance_level: 'fapi',
+          some_future_unsupported_field: 'injected',
+        };
+
+        const capturedBody = await captureBody(undeclared);
+
+        for (const key of Object.keys(capturedBody)) {
+          expect(declaredParams).toContain(key);
+        }
+        for (const key of Object.keys(undeclared)) {
+          expect(capturedBody[key]).toBeUndefined();
+        }
+      });
+
+      it('should forward declared configuration parameters to the Auth0 API', async () => {
+        const declared = {
+          web_origins: ['https://example.com'],
+          client_aliases: ['urn:example'],
+          cross_origin_loc: 'https://example.com/cross-origin',
+          oidc_logout: { backchannel_logout_urls: ['https://example.com/logout'] },
+          sso: true,
+          native_social_login: { apple: { enabled: true } },
+          grant_types: ['authorization_code'],
+          mobile: { ios: { team_id: 'TEAM' } },
+          refresh_token: { rotation_type: 'rotating' },
+          jwt_configuration: { alg: 'RS256' },
+        };
+
+        const capturedBody = await captureBody(declared);
+
+        for (const [key, value] of Object.entries(declared)) {
+          expect(capturedBody[key]).toEqual(value);
+        }
+      });
     });
   });
 

--- a/test/tools/tool-parameter-schema.test.ts
+++ b/test/tools/tool-parameter-schema.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi } from 'vitest';
+import { TOOLS, HANDLERS } from '../../src/tools/index';
+import { mockConfig } from '../mocks/config';
+import '../setup';
+
+vi.mock('../../src/utils/logger', () => ({
+  log: vi.fn(),
+  logInfo: vi.fn(),
+  logError: vi.fn(),
+}));
+
+// Avoid analytics firing real network requests while exercising handlers.
+vi.mock('../../src/utils/analytics.js', () => ({
+  default: { trackTool: vi.fn() },
+}));
+
+type JsonSchema = {
+  type?: string;
+  properties?: Record<string, JsonSchema>;
+};
+
+// Build a benign placeholder for a schema property so the handler can read it
+// without throwing before we have recorded which keys it touched.
+function placeholderFor(schema: JsonSchema | undefined): unknown {
+  switch (schema?.type) {
+    case 'array':
+      return [];
+    case 'object':
+      return {};
+    case 'boolean':
+      return true;
+    case 'number':
+      return 1;
+    default:
+      return 'smoke-test-value';
+  }
+}
+
+// Wrap request.parameters in a Proxy that records every key the handler reads.
+// Handlers destructure their parameters up front (before any network call), so
+// the recorded set is exactly the set of parameters each handler consumes.
+function buildRecordingParameters(properties: Record<string, JsonSchema>) {
+  const accessed = new Set<string>();
+  const target: Record<string, unknown> = {};
+  for (const [key, propSchema] of Object.entries(properties)) {
+    target[key] = placeholderFor(propSchema);
+  }
+  // JS internals probed by JSON.stringify / await, not client-sent parameters.
+  const internals = new Set(['toJSON', 'then', 'catch', 'finally', 'constructor']);
+  const proxy = new Proxy(target, {
+    get(obj, prop, receiver) {
+      if (typeof prop === 'string' && !internals.has(prop)) {
+        accessed.add(prop);
+      }
+      return Reflect.get(obj, prop, receiver);
+    },
+  });
+  return { proxy, accessed };
+}
+
+describe('Tool parameter schema consistency', () => {
+  it('registers a handler for every tool and vice versa', () => {
+    const toolNames = TOOLS.map((t) => t.name).sort();
+    const handlerNames = Object.keys(HANDLERS).sort();
+    expect(handlerNames).toEqual(toolNames);
+  });
+
+  // The server enforces an allowlist that rejects any argument not declared in a
+  // tool's inputSchema. A handler must therefore never read a parameter the schema
+  // omits: if it does, the tool is effectively broken because the client can never
+  // send that parameter (sending it is rejected before the handler runs). This test
+  // exercises every handler and fails if any reads a parameter outside its schema,
+  // keeping each tool's declared inputs and consumed inputs in sync.
+  for (const tool of TOOLS) {
+    it(`${tool.name}: reads only parameters declared in its inputSchema`, async () => {
+      const properties = (tool.inputSchema?.properties ?? {}) as Record<string, JsonSchema>;
+      const declared = new Set(Object.keys(properties));
+      const { proxy, accessed } = buildRecordingParameters(properties);
+
+      const handler = HANDLERS[tool.name];
+      expect(handler, `no handler for ${tool.name}`).toBeDefined();
+
+      // Network calls are mocked/irrelevant: parameters are read before any
+      // request, and handlers catch downstream errors. We only assert no throw
+      // escapes and that no undeclared parameter was read.
+      await expect(
+        handler(
+          { token: mockConfig.token, parameters: proxy as never },
+          { domain: mockConfig.domain }
+        )
+      ).resolves.toBeDefined();
+
+      const undeclared = [...accessed].filter((key) => !declared.has(key));
+      expect(
+        undeclared,
+        `${tool.name} handler reads parameters not in its inputSchema: ${undeclared.join(', ')}`
+      ).toEqual([]);
+    });
+  }
+});


### PR DESCRIPTION
### Summary

This PR resolves the security ticket [SEC-30819](https://auth0team.atlassian.net/browse/SEC-30819).

Previously, the `auth0_create_application` and `auth0_update_application` tool handlers forwarded several parameters to the Auth0 Management API that were not declared in the tools' `inputSchema`. Since MCP clients only surface schema-declared parameters for human approval, undeclared parameters could bypass human-in-the-loop review. This PR closes that gap by removing high-risk parameters, declaring the remaining ones, and adding a server-side allowlist.

### Changes

- **Removed high-risk parameters** from `auth0_create_application` and `auth0_update_application` so they can no longer be forwarded to the Auth0 Management API through these tools: `custom_login_page`, `custom_login_page_on`, `custom_login_page_preview`, `addons`, `encryption_key`, `client_authentication_methods`, `require_proof_of_possession`, `require_pushed_authorization_requests`, `signed_request_object`, `compliance_level`, `form_template`, `client_metadata`, and `initiate_login_uri`.

- **Declared lower-risk parameters in `inputSchema`** so they remain usable but are now surfaced for human approval: `web_origins`, `client_aliases`, `cross_origin_loc`, `oidc_logout`, `sso`, and `native_social_login`. Also added `grant_types`, `jwt_configuration`, `mobile`, and `refresh_token` to `auth0_create_application` (already present on update) so both tools expose a consistent set of parameters.

- **Added a server-side allowlist** in `src/server.ts` that rejects any argument not declared in the invoked tool's `inputSchema.properties` before it reaches the handler, returning `Rejected undeclared parameters: <keys>`. Tools that declare no schema properties skip the check.

- **Declared the `client` parameter** on `auth0_create_resource_server` and `auth0_update_resource_server`. The handlers already consumed it but the schema omitted it, so the new allowlist would otherwise reject it.

- **Added tests:**
  - `test/server.test.ts` — covers the allowlist: rejecting undeclared params, allowing fully-declared params, and skipping enforcement when no schema properties are declared.
  - `test/tools/tool-parameter-schema.test.ts` — enforces the `inputSchema` contract across every tool, failing if any handler reads a parameter not declared in its schema.

### References

https://auth0team.atlassian.net/browse/SEC-30819
https://auth0team.atlassian.net/browse/PSREV-2877

### Testing

1. Created an application with the newly added parameters to the `inputSchema`: `sso`, `web_origins`
<img width="590" height="826" alt="image" src="https://github.com/user-attachments/assets/456edfd4-bec5-4f3f-b69c-407b8c809cd8" />

2. Called the update application tool to add another `web_origin` and set a `grant_type`:
<img width="587" height="159" alt="image" src="https://github.com/user-attachments/assets/3beb548d-4f81-4f54-a717-6bfe1961eb3b" />
<img width="573" height="561" alt="image" src="https://github.com/user-attachments/assets/22e51a06-131c-4b8e-96d2-038b077639a2" />

3. Called the update application tool again to set parameters that don't exist on the `inputSchema`:
<img width="582" height="512" alt="image" src="https://github.com/user-attachments/assets/44bb8131-a5fb-4bcd-8fbc-adab9b0a6216" />

4. Asked the LLM to list the parameters that the Auth0 create application tool takes:
<img width="585" height="130" alt="image" src="https://github.com/user-attachments/assets/e5ff25af-aecc-41d9-adec-40bb3e1a39a5" />
<img width="521" height="268" alt="image" src="https://github.com/user-attachments/assets/fa3f1c52-9c0e-47e7-8d70-ff4e1146f327" />

#### api2 E2E tests (mcp-api):
All mcp-api e2e tests pass in api2
<img width="2061" height="897" alt="image" src="https://github.com/user-attachments/assets/a0a38f30-d18d-47c9-8f68-fc5996c92567" />


#### Steps to test this branch:
- Run `npm run build` and `npm test` — all new and existing tests should pass.
- Call `auth0_create_application` with a removed field (e.g. `custom_login_page`): confirm it is rejected as an undeclared parameter and not forwarded to Auth0.
- Call `auth0_create_application` / `auth0_update_application` with a newly declared field (e.g. `web_origins` or `sso`): confirm it is surfaced in the client's approval prompt and applied on approval.
- Confirm a fully-declared, approved request (e.g. `name` + `app_type` + `web_origins`) still creates/updates the application successfully.

#### All Unit tests pass
#### All tools work when given the parameters defined in their respective `inputSchema`

- [x] This change adds unit test coverage
- [ ] This change adds integration test coverage

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
