### PR TITLE
Add Heap Tracking for Onboarding Tool

### DIFF
--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -55,8 +55,9 @@ const createHandlersWithAnalytics = (): Record<
         // Execute the original handler
         const result = await handler(request, config);
 
-        // Track the tool usage
-        trackEvent.trackTool(name);
+        // Track the tool usage. Handlers signal failure by returning a response
+        // with isError set rather than throwing, so treat those as failures too.
+        trackEvent.trackTool(name, !result?.isError);
 
         return result;
       } catch (error) {

--- a/src/tools/onboarding.ts
+++ b/src/tools/onboarding.ts
@@ -6,6 +6,7 @@ import { createErrorResponse, createSuccessResponse } from '../utils/http-utilit
 import { fetchQuickstartSpec } from '../utils/quickstarts.js';
 import { isFrameworkSupported, SUPPORTED_FRAMEWORKS } from '../utils/onboarding.js';
 import { APPLICATION_HANDLERS } from './applications.js';
+import trackEvent from '../utils/analytics.js';
 
 const APP_TYPE_MAP: Record<string, string> = {
   spa: 'spa',
@@ -137,8 +138,12 @@ export const ONBOARDING_HANDLERS: Record<
     );
 
     if (createResponse.isError) {
+      trackEvent.trackOnboardingStep('create_application', framework, 'failure');
       return createResponse;
     }
+    trackEvent.trackOnboardingStep('create_application', framework, 'success', {
+      app_type: mappedAppType,
+    });
 
     // Parse create response to extract client_id
     let appData: Record<string, any>;
@@ -167,11 +172,13 @@ export const ONBOARDING_HANDLERS: Record<
     );
 
     if (saveResponse.isError) {
+      trackEvent.trackOnboardingStep('save_credentials', framework, 'failure');
       const saveError = saveResponse.content[0]?.text ?? 'Unknown error';
       return createErrorResponse(
         `Error: Application "${resolvedAppName}" was created (client_id: ${clientId}) but credentials could not be saved. ${saveError}`
       );
     }
+    trackEvent.trackOnboardingStep('save_credentials', framework, 'success');
 
     // Parse save response
     let saveData: Record<string, any>;

--- a/src/tools/onboarding.ts
+++ b/src/tools/onboarding.ts
@@ -6,7 +6,7 @@ import { createErrorResponse, createSuccessResponse } from '../utils/http-utilit
 import { fetchQuickstartSpec } from '../utils/quickstarts.js';
 import { isFrameworkSupported, SUPPORTED_FRAMEWORKS } from '../utils/onboarding.js';
 import { APPLICATION_HANDLERS } from './applications.js';
-import trackEvent from '../utils/analytics.js';
+import trackEvent, { OnboardingStep, OnboardingStepStatus } from '../utils/analytics.js';
 
 const APP_TYPE_MAP: Record<string, string> = {
   spa: 'spa',
@@ -138,12 +138,21 @@ export const ONBOARDING_HANDLERS: Record<
     );
 
     if (createResponse.isError) {
-      trackEvent.trackOnboardingStep('create_application', framework, 'failure');
+      trackEvent.trackOnboardingStep(
+        OnboardingStep.CreateApplication,
+        framework,
+        OnboardingStepStatus.Failure
+      );
       return createResponse;
     }
-    trackEvent.trackOnboardingStep('create_application', framework, 'success', {
-      app_type: mappedAppType,
-    });
+    trackEvent.trackOnboardingStep(
+      OnboardingStep.CreateApplication,
+      framework,
+      OnboardingStepStatus.Success,
+      {
+        app_type: mappedAppType,
+      }
+    );
 
     // Parse create response to extract client_id
     let appData: Record<string, any>;
@@ -172,13 +181,21 @@ export const ONBOARDING_HANDLERS: Record<
     );
 
     if (saveResponse.isError) {
-      trackEvent.trackOnboardingStep('save_credentials', framework, 'failure');
+      trackEvent.trackOnboardingStep(
+        OnboardingStep.SaveCredentials,
+        framework,
+        OnboardingStepStatus.Failure
+      );
       const saveError = saveResponse.content[0]?.text ?? 'Unknown error';
       return createErrorResponse(
         `Error: Application "${resolvedAppName}" was created (client_id: ${clientId}) but credentials could not be saved. ${saveError}`
       );
     }
-    trackEvent.trackOnboardingStep('save_credentials', framework, 'success');
+    trackEvent.trackOnboardingStep(
+      OnboardingStep.SaveCredentials,
+      framework,
+      OnboardingStepStatus.Success
+    );
 
     // Parse save response
     let saveData: Record<string, any>;

--- a/src/tools/quickstarts.ts
+++ b/src/tools/quickstarts.ts
@@ -13,6 +13,7 @@ import { fetchWithOptions } from '../utils/fetch.js';
 import { calculateUrlUpdates, resolvePlaceholders } from '../utils/quickstart-guide.js';
 import { detectExistingEnvFile } from '../utils/credentials-writer.js';
 import { APPLICATION_HANDLERS } from './applications.js';
+import trackEvent from '../utils/analytics.js';
 
 export const QUICKSTART_TOOLS: Tool[] = [
   {
@@ -239,6 +240,9 @@ export const QUICKSTART_HANDLERS: Record<
         config
       );
       if (updateResponse.isError) {
+        trackEvent.trackOnboardingStep('quickstart_guide', framework, 'failure', {
+          failure_stage: 'update_callback_urls',
+        });
         const errorDetail = updateResponse.content?.[0]?.text || 'Unknown error';
         return createErrorResponse(
           `Error: Failed to update application callback URLs. ${errorDetail}`
@@ -281,6 +285,10 @@ export const QUICKSTART_HANDLERS: Record<
       ? `An existing environment file was detected at "${envFilePath}"; use it as-is and skip ` +
         `any environment-variable or .env setup steps in the quickstart_prompt; do not create or copy a new .env file.`
       : '';
+
+    trackEvent.trackOnboardingStep('quickstart_guide', framework, 'success', {
+      urls_updated: updatePayload !== null,
+    });
 
     return createSuccessResponse({
       success: true,

--- a/src/tools/quickstarts.ts
+++ b/src/tools/quickstarts.ts
@@ -13,7 +13,7 @@ import { fetchWithOptions } from '../utils/fetch.js';
 import { calculateUrlUpdates, resolvePlaceholders } from '../utils/quickstart-guide.js';
 import { detectExistingEnvFile } from '../utils/credentials-writer.js';
 import { APPLICATION_HANDLERS } from './applications.js';
-import trackEvent from '../utils/analytics.js';
+import trackEvent, { OnboardingStep, OnboardingStepStatus } from '../utils/analytics.js';
 
 export const QUICKSTART_TOOLS: Tool[] = [
   {
@@ -240,9 +240,14 @@ export const QUICKSTART_HANDLERS: Record<
         config
       );
       if (updateResponse.isError) {
-        trackEvent.trackOnboardingStep('quickstart_guide', framework, 'failure', {
-          failure_stage: 'update_callback_urls',
-        });
+        trackEvent.trackOnboardingStep(
+          OnboardingStep.QuickstartGuide,
+          framework,
+          OnboardingStepStatus.Failure,
+          {
+            failure_stage: 'update_callback_urls',
+          }
+        );
         const errorDetail = updateResponse.content?.[0]?.text || 'Unknown error';
         return createErrorResponse(
           `Error: Failed to update application callback URLs. ${errorDetail}`
@@ -286,9 +291,14 @@ export const QUICKSTART_HANDLERS: Record<
         `any environment-variable or .env setup steps in the quickstart_prompt; do not create or copy a new .env file.`
       : '';
 
-    trackEvent.trackOnboardingStep('quickstart_guide', framework, 'success', {
-      urls_updated: updatePayload !== null,
-    });
+    trackEvent.trackOnboardingStep(
+      OnboardingStep.QuickstartGuide,
+      framework,
+      OnboardingStepStatus.Success,
+      {
+        urls_updated: updatePayload !== null,
+      }
+    );
 
     return createSuccessResponse({
       success: true,

--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -14,8 +14,13 @@ const packageVersion = packageJson.version;
 // Constants
 const EVENT_NAME_PREFIX = 'auth0-mcp-server';
 
+// Analytics schema version, emitted to Heap as `analytics_version`. Bump when the
+// meaning of tracked data changes so the shift is queryable in Heap.
+const ANALYTICS_SCHEMA_VERSION = "2.0.0";
+
 // Common property keys
 const VERSION_KEY = 'version';
+const ANALYTICS_VERSION_KEY = 'analytics_version';
 const OS_KEY = 'os';
 const ARCH_KEY = 'arch';
 const NODE_VERSION = 'node_version';
@@ -43,6 +48,7 @@ interface HeapEvent {
 export class TrackEvent {
   private appId: string;
   private endpoint: string;
+  private identity: string;
   /**
    * Constructor for TrackEvent
    *
@@ -52,6 +58,9 @@ export class TrackEvent {
   constructor(appId: string, endpoint: string) {
     this.appId = appId;
     this.endpoint = endpoint;
+    // Generate the identity once so all events in a session share one identity,
+    // rather than creating a new UUID per event (which fragments user tracking).
+    this.identity = crypto.randomUUID();
   }
   /**
    * Track a command run event
@@ -96,6 +105,35 @@ export class TrackEvent {
     const eventName = `${EVENT_NAME_PREFIX}-tool-${toolName}`;
     const properties = {
       success,
+      ...this.getCommonProperties(),
+    };
+    this.track(eventName, properties);
+  }
+
+  /**
+   * Track an onboarding flow step
+   *
+   * Captures the framework dimension and per-step outcome that the generic
+   * tool-usage event does not, so the multi-step onboarding flow can be
+   * analyzed end to end.
+   *
+   * @param step - The onboarding step (e.g. 'create_application', 'save_credentials', 'quickstart_guide')
+   * @param framework - The framework being onboarded
+   * @param outcome - Whether the step succeeded or failed
+   * @param extraProperties - Additional step-specific properties
+   */
+  trackOnboardingStep(
+    step: string,
+    framework: string,
+    outcome: 'success' | 'failure',
+    extraProperties?: Record<string, string | number | boolean>
+  ): void {
+    const eventName = `${EVENT_NAME_PREFIX}-onboarding-${step}`;
+    const properties = {
+      step,
+      framework,
+      success: outcome === 'success',
+      ...extraProperties,
       ...this.getCommonProperties(),
     };
     this.track(eventName, properties);
@@ -159,7 +197,7 @@ export class TrackEvent {
   ): HeapEvent {
     return {
       app_id: this.appId,
-      identity: crypto.randomUUID(),
+      identity: this.identity,
       event: eventName,
       timestamp: this.timestamp(),
       properties: {
@@ -226,6 +264,7 @@ export class TrackEvent {
     return {
       [APP_NAME]: EVENT_NAME_PREFIX,
       [VERSION_KEY]: packageVersion,
+      [ANALYTICS_VERSION_KEY]: ANALYTICS_SCHEMA_VERSION,
       [OS_KEY]: process.platform,
       [ARCH_KEY]: process.arch,
       [NODE_VERSION]: process.version,

--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -16,7 +16,7 @@ const EVENT_NAME_PREFIX = 'auth0-mcp-server';
 
 // Analytics schema version, emitted to Heap as `analytics_version`. Bump when the
 // meaning of tracked data changes so the shift is queryable in Heap.
-const ANALYTICS_SCHEMA_VERSION = "2.0.0";
+const ANALYTICS_SCHEMA_VERSION = '2.0.0';
 
 // Common property keys
 const VERSION_KEY = 'version';

--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -34,6 +34,23 @@ const APP_NAME = 'app_name';
  */
 export type CredentialResolutionFallbackReason = 'unsupported' | 'cdn_unavailable';
 
+/**
+ * Steps in the onboarding flow, used as the discriminator on onboarding analytics events.
+ */
+export enum OnboardingStep {
+  CreateApplication = 'create_application',
+  SaveCredentials = 'save_credentials',
+  QuickstartGuide = 'quickstart_guide',
+}
+
+/**
+ * Outcome of an onboarding step.
+ */
+export enum OnboardingStepStatus {
+  Failure = 'failure',
+  Success = 'success',
+}
+
 interface HeapEvent {
   app_id: string;
   identity?: string;
@@ -117,22 +134,22 @@ export class TrackEvent {
    * tool-usage event does not, so the multi-step onboarding flow can be
    * analyzed end to end.
    *
-   * @param step - The onboarding step (e.g. 'create_application', 'save_credentials', 'quickstart_guide')
+   * @param step - The onboarding step
    * @param framework - The framework being onboarded
    * @param outcome - Whether the step succeeded or failed
    * @param extraProperties - Additional step-specific properties
    */
   trackOnboardingStep(
-    step: string,
+    step: OnboardingStep,
     framework: string,
-    outcome: 'success' | 'failure',
+    outcome: OnboardingStepStatus,
     extraProperties?: Record<string, string | number | boolean>
   ): void {
-    const eventName = `${EVENT_NAME_PREFIX}-onboarding-${step}`;
+    const eventName = `${EVENT_NAME_PREFIX}-onboarding`;
     const properties = {
       step,
       framework,
-      success: outcome === 'success',
+      success: outcome === OnboardingStepStatus.Success,
       ...extraProperties,
       ...this.getCommonProperties(),
     };

--- a/test/utils/analytics.test.ts
+++ b/test/utils/analytics.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { TrackEvent } from '../../src/utils/analytics';
+import { OnboardingStep, OnboardingStepStatus, TrackEvent } from '../../src/utils/analytics';
 
 // Mock dependencies
 vi.mock('crypto', () => ({
@@ -154,10 +154,14 @@ describe('TrackEvent', () => {
     it('should track an onboarding step with framework and success outcome', () => {
       const spy = vi.spyOn(trackEvent as any, 'track');
 
-      trackEvent.trackOnboardingStep('create_application', 'react', 'success');
+      trackEvent.trackOnboardingStep(
+        OnboardingStep.CreateApplication,
+        'react',
+        OnboardingStepStatus.Success
+      );
 
       expect(spy).toHaveBeenCalledWith(
-        'auth0-mcp-server-onboarding-create_application',
+        'auth0-mcp-server-onboarding',
         expect.objectContaining({
           step: 'create_application',
           framework: 'react',
@@ -169,12 +173,17 @@ describe('TrackEvent', () => {
     it('should track a failure outcome and include extra properties', () => {
       const spy = vi.spyOn(trackEvent as any, 'track');
 
-      trackEvent.trackOnboardingStep('quickstart_guide', 'nextjs', 'failure', {
-        failure_stage: 'update_callback_urls',
-      });
+      trackEvent.trackOnboardingStep(
+        OnboardingStep.QuickstartGuide,
+        'nextjs',
+        OnboardingStepStatus.Failure,
+        {
+          failure_stage: 'update_callback_urls',
+        }
+      );
 
       expect(spy).toHaveBeenCalledWith(
-        'auth0-mcp-server-onboarding-quickstart_guide',
+        'auth0-mcp-server-onboarding',
         expect.objectContaining({
           step: 'quickstart_guide',
           framework: 'nextjs',
@@ -189,7 +198,10 @@ describe('TrackEvent', () => {
     it('should track credential resolution with framework, resolution path, and secret generated', () => {
       const spy = vi.spyOn(trackEvent as any, 'track');
 
-      trackEvent.trackCredentialResolution('nextjs', 'spec', true, ['AUTH0_DOMAIN', 'AUTH0_CLIENT_ID']);
+      trackEvent.trackCredentialResolution('nextjs', 'spec', true, [
+        'AUTH0_DOMAIN',
+        'AUTH0_CLIENT_ID',
+      ]);
 
       expect(spy).toHaveBeenCalledWith(
         'auth0-mcp-server-credential-resolution',
@@ -205,7 +217,10 @@ describe('TrackEvent', () => {
     it('should track fallback path when spec is unavailable', () => {
       const spy = vi.spyOn(trackEvent as any, 'track');
 
-      trackEvent.trackCredentialResolution('sveltekit', 'fallback', false, ['AUTH0_SECRET', 'AUTH0_DOMAIN']);
+      trackEvent.trackCredentialResolution('sveltekit', 'fallback', false, [
+        'AUTH0_SECRET',
+        'AUTH0_DOMAIN',
+      ]);
 
       expect(spy).toHaveBeenCalledWith(
         'auth0-mcp-server-credential-resolution',
@@ -221,7 +236,13 @@ describe('TrackEvent', () => {
     it('should include fallback_reason when provided', () => {
       const spy = vi.spyOn(trackEvent as any, 'track');
 
-      trackEvent.trackCredentialResolution('react', 'fallback', false, ['AUTH0_DOMAIN'], 'cdn_unavailable');
+      trackEvent.trackCredentialResolution(
+        'react',
+        'fallback',
+        false,
+        ['AUTH0_DOMAIN'],
+        'cdn_unavailable'
+      );
 
       expect(spy).toHaveBeenCalledWith(
         'auth0-mcp-server-credential-resolution',
@@ -296,7 +317,7 @@ describe('TrackEvent', () => {
         // Arrange
         const eventName = 'Test Event';
         const customProps = { test: 'value' };
-        const timestampSpy = vi.spyOn(trackEvent as any, 'timestamp').mockReturnValue(12345);
+        vi.spyOn(trackEvent as any, 'timestamp').mockReturnValue(12345);
 
         // Act
         const result = (trackEvent as any).createEvent(eventName, customProps);

--- a/test/utils/analytics.test.ts
+++ b/test/utils/analytics.test.ts
@@ -137,6 +137,54 @@ describe('TrackEvent', () => {
     });
   });
 
+  describe('identity', () => {
+    it('should generate the identity once in the constructor', () => {
+      expect((trackEvent as any).identity).toBe('mock-uuid');
+    });
+
+    it('should reuse the same identity across multiple events', () => {
+      const event1 = (trackEvent as any).createEvent('event-one');
+      const event2 = (trackEvent as any).createEvent('event-two');
+
+      expect(event1.identity).toBe(event2.identity);
+    });
+  });
+
+  describe('trackOnboardingStep', () => {
+    it('should track an onboarding step with framework and success outcome', () => {
+      const spy = vi.spyOn(trackEvent as any, 'track');
+
+      trackEvent.trackOnboardingStep('create_application', 'react', 'success');
+
+      expect(spy).toHaveBeenCalledWith(
+        'auth0-mcp-server-onboarding-create_application',
+        expect.objectContaining({
+          step: 'create_application',
+          framework: 'react',
+          success: true,
+        })
+      );
+    });
+
+    it('should track a failure outcome and include extra properties', () => {
+      const spy = vi.spyOn(trackEvent as any, 'track');
+
+      trackEvent.trackOnboardingStep('quickstart_guide', 'nextjs', 'failure', {
+        failure_stage: 'update_callback_urls',
+      });
+
+      expect(spy).toHaveBeenCalledWith(
+        'auth0-mcp-server-onboarding-quickstart_guide',
+        expect.objectContaining({
+          step: 'quickstart_guide',
+          framework: 'nextjs',
+          success: false,
+          failure_stage: 'update_callback_urls',
+        })
+      );
+    });
+  });
+
   describe('trackCredentialResolution', () => {
     it('should track credential resolution with framework, resolution path, and secret generated', () => {
       const spy = vi.spyOn(trackEvent as any, 'track');
@@ -343,6 +391,7 @@ describe('TrackEvent', () => {
         expect(result).toEqual({
           app_name: 'auth0-mcp-server',
           version: expect.any(String),
+          analytics_version: expect.stringMatching(/^\d+\.\d+\.\d+$/),
           os: expect.any(String),
           arch: expect.any(String),
           node_version: expect.any(String),


### PR DESCRIPTION
### Changes

This change adds Heap analytics tracking for the onboarding flow and hardens how analytics events are emitted. Previously, tool usage was tracked as a single generic event with a unique, randomly generated identity per event, which fragmented session tracking and provided no visibility into the multi-step onboarding flow. This change introduces a per-session identity, a schema version, per-step onboarding events, and credential-resolution tracking.

The following changes have been implemented:
1. **Session scoped identity**: `TrackEvent` now generates a single `identity` (UUID) once in its constructor and reuses it for every event in the session, instead of minting a new UUID per event. This stops a single user's events from being scattered across many identities in Heap.
2. **Analytics Schema Versioning**: Added an `ANALYTICS_SCHEMA_VERSION` (`2.0.0`) emitted on every event as the `analytics_version` common property, so changes to the meaning of tracked data are queryable in Heap and old vs. new data can be distinguished.
3. **Tool Success Tracking**: `trackTool()` now accepts a `success` flag (default `true`). Since handlers signal failure by returning a response with `isError` set rather than throwing, the analytics wrapper in `src/tools.index.ts` now passes `!result?.isError`, so failed tool calls are recorded as failures.
4. **Onboarding Step Tracking**: Added `trackOnboardingStep()`, which emits `auth0-mcp-server-onboarding-<step>` events capturing the `framework` and per step `success`.
5. **Credential Resolution Tracking**: Added `trackCredentialResolution()`, emitting an `auth0-mcp-server-credential-resolution` event. It records whether the spec or fallback path was used, whether `AUTH0_SECRET` was auth-generated, the sorted env keys written, and a `CredentialResolutionFallbackReason` when the fallback path was taken.

Updates to the following files:
- `src/utils/analytics.ts` - session scoped identity, `ANALYTICS_SCHEMA_VERSION` / `analytics_version`, `trackTool` success flag, new `trackOnboardingStep()` and `trackCredentialResolution()` methods, and the exported `CredentialResolutionFallbackReason` type.
- `src/tools/index.ts` - analytics wrapper now passes tool success (`!result?.isError`) to `trackTool`.
- `src/tools/onboarding.ts` - emits onboarding step events for `create_application` and `save_credentials`.
- `src/tools/quickstarts.ts` - emits onboarding step events for the `configure and get quickstart` guide step.

### References
- 

### Testing

Unit tests in `test/utils/analytics.test.ts` cover the session-stable identity (same identity reused across events), the `analytics_version` common property, `trackTool `success/failure flagging, and the new t`rackOnboardingStep()` and `trackCredentialResolution()` event shapes (event names, framework dimension, sorted keys_written, and conditional fallback_reason). `test/tools/quickstarts.test.ts` was updated for the `configure and get quickstart` step tracking.

#### Data in Heap, onboarding tool tracking is showing up in Heap data visualizer:
<img width="1688" height="469" alt="image" src="https://github.com/user-attachments/assets/93061663-c296-47c5-b3cf-850c99f3fac9" />

These changes can be tested by reviewers:

  1. Switch to the f`eat/DXAA-onboarding-heap-tracking` branch.
  2. Run `npm run build`.
  3. Initialize the MCP server: `npx . init --client vscode` (or your preferred client).
  4. Ensure the MCP server is running.
  5. Run `auth0_onboarding` (e.g. framework: "nextjs") and verify Heap receives
  `auth0-mcp-server-onboarding-create_application` and `-save_credentials` events, plus a
  `-credential-resolution` event, all sharing one identity and carrying `analytics_version`.
  6. Trigger a failure (e.g. an unsupported framework or an intentionally failing save) and verify the corresponding step event records success: false.
  7. Run the unit tests: `npx vitest run test/utils/analytics.test.ts`

- [x] This change adds unit test coverage
- [ ] This change adds integration test coverage

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
