### PR TITLE
Add javascript, express, and python onboarding quickstarts

### DIFF
--- a/src/utils/env-credentials.ts
+++ b/src/utils/env-credentials.ts
@@ -41,8 +41,17 @@ type ResolvedCredentials =
       credentialMap: Record<string, string>;
       envFilePath: string;
       generated_keys: string[];
+      /** Whether the session-cookie secret was auto-generated (drives the secret_generated analytic). */
+      secret_generated: boolean;
     }
   | { success: false; error: string };
+
+/**
+ * CDN spec placeholder for the session-cookie secret. We never populate its input
+ * (`sessionCookieSecret`) — the value is generated locally — so any sensitive var
+ * templated with this token is the session secret, regardless of its output name.
+ */
+const SESSION_SECRET_PLACEHOLDER = '%AUTH0_SECRET%';
 
 /**
  * Resolves Auth0 credentials for the given framework and writes them to the project's env file.
@@ -165,7 +174,7 @@ export async function resolveAndWriteCredentials(
   trackEvent.trackCredentialResolution(
     framework,
     resolutionPath,
-    generatedKeys.includes('AUTH0_SECRET'),
+    resolved.secret_generated,
     credentialsInfo.keys_written,
     fallbackReason
   );
@@ -202,7 +211,9 @@ export async function resolveAndWriteCredentials(
  * with actual values derived from the spec's placeholder→inputKey mapping.
  *
  * SPA frameworks (empty secretKeys) skip the Management API call entirely.
- * AUTH0_SECRET is generated only when required and not already present in the existing env file.
+ * The session-cookie secret is generated only when required and not already present in the
+ * existing env file. It is identified by the %AUTH0_SECRET% placeholder rather than a fixed
+ * output name, since that name varies by framework (AUTH0_SECRET for Next.js, SECRET for Express).
  */
 async function buildSpecCredentials(
   params: EnvCredentialsParams,
@@ -283,12 +294,17 @@ async function buildSpecCredentials(
   const existingEnv = parseEnvFile(envFilePath);
   const credentialMap: Record<string, string> = {};
   const generated_keys: string[] = [];
+  let secret_generated = false;
 
   for (const entry of varEntries) {
-    if (entry.name === 'AUTH0_SECRET') {
-      if (!existingEnv['AUTH0_SECRET']) {
+    // Session-cookie secret: detected by the %AUTH0_SECRET% placeholder, not the output
+    // name (which varies by framework), since we generate it locally rather than fetch it.
+    // Generate only if not already present in the env file.
+    if (entry.sensitive && entry.value.includes(SESSION_SECRET_PLACEHOLDER)) {
+      if (!existingEnv[entry.name]) {
         credentialMap[entry.name] = randomBytes(32).toString('hex');
         generated_keys.push(entry.name);
+        secret_generated = true;
       }
       continue;
     }
@@ -299,7 +315,7 @@ async function buildSpecCredentials(
     }
   }
 
-  return { success: true, credentialMap, envFilePath, generated_keys };
+  return { success: true, credentialMap, envFilePath, generated_keys, secret_generated };
 }
 
 /**
@@ -366,7 +382,7 @@ async function buildFallbackCredentials(
       ...(resolvedCallbackUrl ? { AUTH0_CALLBACK_URL: resolvedCallbackUrl } : {}),
     };
 
-    return { success: true, credentialMap, envFilePath, generated_keys: [] };
+    return { success: true, credentialMap, envFilePath, generated_keys: [], secret_generated: false };
   } catch (sdkError: any) {
     let error = `Failed to retrieve application: ${sdkError.message || 'Unknown error'}`;
     if (sdkError.statusCode === 404) {

--- a/src/utils/onboarding.ts
+++ b/src/utils/onboarding.ts
@@ -40,6 +40,9 @@ export const FRAMEWORK_FILENAMES = {
   vue: 'vuejs-quickstart-definition.json',
   angular: 'angular-quickstart-definition.json',
   nextjs: 'nextjs-quickstart-definition.json',
+  javascript: 'vanillajs-quickstart-definition.json',
+  express: 'express-quickstart-definition.json',
+  python: 'python-quickstart-definition.json',
 } as const;
 
 export const SUPPORTED_FRAMEWORKS = Object.keys(FRAMEWORK_FILENAMES) as Array<

--- a/test/tools/quickstarts.test.ts
+++ b/test/tools/quickstarts.test.ts
@@ -1225,7 +1225,9 @@ describe('auth0_get_quickstart_guide', () => {
       );
       expect(response.isError).toBe(true);
       expect(response.content[0].text).toContain('Unsupported framework');
-      expect(response.content[0].text).toContain('react, vue, angular, nextjs');
+      expect(response.content[0].text).toContain(
+        'react, vue, angular, nextjs, javascript, express, python'
+      );
     });
 
     it('should accept mixed-case framework values', async () => {

--- a/test/utils/env-credentials.test.ts
+++ b/test/utils/env-credentials.test.ts
@@ -107,7 +107,26 @@ const specWithSecret64 = {
     ...specWithSecret.envSnippet,
     entries: [
       ...specWithSecret.envSnippet.entries,
-      { type: 'var' as const, name: 'AUTH0_SECRET', value: '{yourSecret}' },
+      { type: 'var' as const, name: 'AUTH0_SECRET', value: '%AUTH0_SECRET%', sensitive: true },
+    ],
+  },
+};
+
+// Express names its session-cookie secret `SECRET` (not `AUTH0_SECRET`) but still
+// templates it as %AUTH0_SECRET% with sensitive: true. Generation must key off the
+// placeholder, not the output name, so this var gets a value.
+const specExpress = {
+  ...specWithSecret,
+  envSnippet: {
+    type: 'env',
+    language: 'shell',
+    fileName: '.env',
+    entries: [
+      { type: 'var' as const, name: 'ISSUER_BASE_URL', value: 'https://%AUTH0_DOMAIN%' },
+      { type: 'var' as const, name: 'CLIENT_ID', value: '%AUTH0_CLIENT_ID%' },
+      { type: 'var' as const, name: 'SECRET', value: '%AUTH0_SECRET%', sensitive: true },
+      { type: 'var' as const, name: 'BASE_URL', value: '%APP_SCHEME%://%APP_DOMAIN%:%PORT%' },
+      { type: 'var' as const, name: 'PORT', value: '%PORT%' },
     ],
   },
 };
@@ -453,6 +472,38 @@ describe('resolveAndWriteCredentials — spec path (supported framework)', () =>
 
     const credentialMap = mockWriteCredentialsToEnv.mock.calls[0][0];
     expect(credentialMap).not.toHaveProperty('AUTH0_SECRET');
+  });
+
+  it('generates the session secret for Express, which names the var SECRET', async () => {
+    mockFetchQuickstartSpec.mockResolvedValue(specExpress);
+    mockParseEnvFile.mockReturnValue({});
+
+    const result = await resolveAndWriteCredentials(specParams, config, token);
+
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.generated_keys).toContain('SECRET');
+
+    const credentialMap = mockWriteCredentialsToEnv.mock.calls[0][0];
+    // Session secret generated under its Express name.
+    expect(credentialMap['SECRET']).toMatch(/^[0-9a-f]{64}$/);
+    // Non-secret vars all resolve — none dropped for unresolved %…% tokens.
+    expect(credentialMap['ISSUER_BASE_URL']).toBe(`https://${config.domain}`);
+    expect(credentialMap['CLIENT_ID']).toBe(clientId);
+    expect(credentialMap['BASE_URL']).toBe('http://localhost:3000');
+    expect(credentialMap['PORT']).toBe('3000');
+  });
+
+  it('skips Express SECRET generation when already present in the env file', async () => {
+    mockFetchQuickstartSpec.mockResolvedValue(specExpress);
+    mockParseEnvFile.mockReturnValue({ SECRET: 'existing-secret' });
+
+    const result = await resolveAndWriteCredentials(specParams, config, token);
+
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.generated_keys).not.toContain('SECRET');
+
+    const credentialMap = mockWriteCredentialsToEnv.mock.calls[0][0];
+    expect(credentialMap).not.toHaveProperty('SECRET');
   });
 
   it('returns a helpful error when base_url is malformed', async () => {

--- a/test/utils/onboarding.test.ts
+++ b/test/utils/onboarding.test.ts
@@ -36,8 +36,8 @@ describe('isFrameworkSupported', () => {
 
   it('returns false for unsupported frameworks', () => {
     expect(isFrameworkSupported('sveltekit')).toBe(false);
-    expect(isFrameworkSupported('express')).toBe(false);
     expect(isFrameworkSupported('flask')).toBe(false);
+    expect(isFrameworkSupported('django')).toBe(false);
     expect(isFrameworkSupported('')).toBe(false);
   });
 });

--- a/test/utils/quickstarts.test.ts
+++ b/test/utils/quickstarts.test.ts
@@ -16,6 +16,9 @@ const FRAMEWORK_FILENAMES: Record<string, string> = {
   vue: 'vuejs-quickstart-definition.json',
   angular: 'angular-quickstart-definition.json',
   nextjs: 'nextjs-quickstart-definition.json',
+  javascript: 'vanillajs-quickstart-definition.json',
+  express: 'express-quickstart-definition.json',
+  python: 'python-quickstart-definition.json',
 };
 
 const defUrl = (framework: string) =>
@@ -176,6 +179,9 @@ describe('fetchQuickstartSpec', () => {
     ['vue', 'vuejs-quickstart-definition.json'],
     ['angular', 'angular-quickstart-definition.json'],
     ['nextjs', 'nextjs-quickstart-definition.json'],
+    ['javascript', 'vanillajs-quickstart-definition.json'],
+    ['express', 'express-quickstart-definition.json'],
+    ['python', 'python-quickstart-definition.json'],
   ])('maps %s to filename %s', async (framework, expectedFilename) => {
     let capturedUrl = '';
     server.use(


### PR DESCRIPTION
### Changes

Adds three more frameworks to the Auth0 onboarding quickstarts and fixes a bug in session-cookie secret generation.

**New quickstart frameworks** (`src/utils/onboarding.ts`)
- Registers three new entries in `FRAMEWORK_FILENAMES`, which drives `SUPPORTED_FRAMEWORKS`:
  - `javascript` → `vanillajs-quickstart-definition.json`
  - `express` → `express-quickstart-definition.json`
  - `python` → `python-quickstart-definition.json`
- The definitions themselves are served from the Auth0 CDN at runtime; this change only makes the MCP server recognize the frameworks and route them to the correct definition file.

**Fix: session-cookie secret not generated for Express** (`src/utils/env-credentials.ts`)
- Secret generation in `buildSpecCredentials` was gated on the output env var being named exactly `AUTH0_SECRET`. Express names it `SECRET`, so the secret was never generated and got silently dropped from the written `.env`, breaking the sample app on startup.
- The session secret is now detected by its `sensitive` flag combined with the `%AUTH0_SECRET%` value-template placeholder, rather than the hardcoded output name. This makes generation framework-agnostic (Next.js `AUTH0_SECRET`, Express `SECRET`, Python `AUTH0_SECRET` are all covered). `AUTH0_CLIENT_SECRET` is unaffected because it resolves from a different placeholder.
- The `secret_generated` analytic is now driven by an explicit flag on the resolved result instead of `generated_keys.includes('AUTH0_SECRET')`, keeping the signal correct regardless of the var name or any future generated keys.

### References

- https://auth0team.atlassian.net/browse/DXAA-654
- https://auth0team.atlassian.net/browse/DXAA-655
- https://auth0team.atlassian.net/browse/DXAA-656

### Testing

- Run the credential and framework unit tests: `npx vitest run test/utils/env-credentials.test.ts test/utils/onboarding.test.ts test/utils/quickstarts.test.ts test/tools/quickstarts.test.ts`.
- New coverage in `test/utils/env-credentials.test.ts` proves the fix: an Express-shaped spec generates a 64-hex-char `SECRET`, resolves `ISSUER_BASE_URL`/`CLIENT_ID`/`BASE_URL`/`PORT` with no dropped placeholders, and skips generation when a `SECRET` already exists in the env file. The updated `specWithSecret64` fixture now mirrors real CDN data (`sensitive: true`, `value: '%AUTH0_SECRET%'`).
- Framework-list tests updated for the three new supported frameworks.
- End-to-end sanity (optional, needs a tenant): run the `auth0_onboarding` tool with `framework: "express"` and confirm the written `.env` contains `SECRET=<64 hex chars>` alongside `ISSUER_BASE_URL`, `CLIENT_ID`, `BASE_URL`, `PORT`.

- [x] This change adds unit test coverage
- [ ] This change adds integration test coverage

### Checklist

- [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [ ] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors