### PR TITLE
updating cli output for device confirmation explanation

### DIFF
--- a/src/auth/device-auth-flow.ts
+++ b/src/auth/device-auth-flow.ts
@@ -53,8 +53,7 @@ async function requestAuthorization(selectedScopes?: string[], interaction: bool
     const jsonRes = await response.json();
     if (!jsonRes.error) {
       cliOutput(
-        `\nYour device confirmation code is: ${chalk.bold.green(jsonRes.user_code)}\n` +
-          `\nNext, press Enter to open a browser window and sign in. Once the browser opens, confirm that the code shown there matches the one above, then approve the request to finish authenticating.\n`
+        `\nPress ${chalk.bold('Enter')} to log in via the browser, your device code is: ${chalk.bold.green(jsonRes.user_code)}\n`
       );
       // Wait for user to press Enter to open browser
       if (interaction) {

--- a/src/auth/device-auth-flow.ts
+++ b/src/auth/device-auth-flow.ts
@@ -52,7 +52,10 @@ async function requestAuthorization(selectedScopes?: string[], interaction: bool
 
     const jsonRes = await response.json();
     if (!jsonRes.error) {
-      cliOutput(`\nVerify this code on screen: ${chalk.bold.green(jsonRes.user_code)}\n`);
+      cliOutput(
+        `\nYour device confirmation code is: ${chalk.bold.green(jsonRes.user_code)}\n` +
+          `\nNext, press Enter to open a browser window and sign in. Once the browser opens, confirm that the code shown there matches the one above, then approve the request to finish authenticating.\n`
+      );
       // Wait for user to press Enter to open browser
       if (interaction) {
         await promptForBrowserPermission();

--- a/src/utils/terminal.ts
+++ b/src/utils/terminal.ts
@@ -244,13 +244,10 @@ class Terminal {
     });
 
     return new Promise<boolean>((resolve) => {
-      rl.question(
-        chalk.yellow(`Press Enter to open the browser to log in or ${chalk.cyan('^C')} to quit.\n`),
-        () => {
-          rl.close();
-          resolve(true);
-        }
-      );
+      rl.question('', () => {
+        rl.close();
+        resolve(true);
+      });
     });
   }
 


### PR DESCRIPTION
### Changes

Please describe both what is changing and why this is important. Include:

As part of the MCP onboarding experiment currently running, the AA team has noticed that users are entering their device authorization code into the feedback component. We believe that there might be confusion about how/where users are supposed to verify the code. 

The current experience tells users to verify the code on the screen, but it doesn't explicitly tell the user which screen or where to verify the code. Furthermore, the message to open their browser for authentication appears after the device code verification message, making it look like users have to verify the code before opening the browser.

Before:
<img width="513" height="58" alt="image" src="https://github.com/user-attachments/assets/6c322eb5-fcbd-4598-8f2e-d5c08409a7c1" />

The change introduced updates the messaging to remove the "verify" comment. Users now see a text telling them to hit "Enter" to log in via the browser with their device code:
<img width="701" height="330" alt="image" src="https://github.com/user-attachments/assets/cf701ef4-f633-4c16-a3ec-34810f6ee97f" />


### References

Please include relevant links supporting this change such as a:


### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

1. Run the `npx` command to initialize and authenticate the MCP server
2. Select scopes
3. Verify the message in the output

- [ ] This change adds unit test coverage
- [ ] This change adds integration test coverage

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
