### PR TITLE
fix(logs): add valid field names and examples to q parameter description

### DIFF
--- a/src/tools/logs.ts
+++ b/src/tools/logs.ts
@@ -22,7 +22,12 @@ export const LOG_TOOLS: Tool[] = [
         },
         q: {
           type: 'string',
-          description: 'Query in Lucene query string syntax. Optional, used for filtering logs.',
+          description:
+            'Lucene query string to filter logs. ' +
+            'Valid fields: user_name (stores email for database users), user_id, type, ' +
+            'client_id, client_name, ip, connection, description, date. ' +
+            'Examples: user_name:"john@example.com", type:f, client_name:MyApp AND type:fp. ' +
+            'Do NOT use user_email — this field does not exist in Auth0 logs.',
         },
         sort: {
           type: 'string',

--- a/test/benchmark/README.md
+++ b/test/benchmark/README.md
@@ -1,0 +1,21 @@
+# Schema Fix Benchmarks
+
+Each file in this directory benchmarks one tool schema fix from the 400-error analysis (Apr 2025–Jul 2026).
+
+## Approach
+
+Tests are deterministic — no LLM is invoked. Each file encodes:
+
+1. **Bad inputs**: fixed parameters that represent what an LLM would send based on the *current* schema description. The MSW mock validates the request and returns 400 for known-invalid values, matching the real API behavior.
+2. **Good inputs**: corrected parameters a well-guided LLM would send after the schema fix. The mock returns 200.
+3. **Schema inspection**: assertions on the tool's `inputSchema` that verify the fix is present (enum values, description content, required fields, property constraints).
+
+## Structure
+
+Each benchmark file runs as part of `npm test`. The "before" tests document the gap. The "after" tests verify the fix. Both suites pass after a fix is applied — the "before" suite remains as a regression guard.
+
+## Files
+
+| File | Tool | Error Count | Root Cause |
+|------|------|-------------|------------|
+| `logs.benchmark.test.ts` | `auth0_list_logs` | 661 | `q` description missing valid field names — LLM sends `user_email` which does not exist in Auth0 logs |

--- a/test/benchmark/logs.benchmark.test.ts
+++ b/test/benchmark/logs.benchmark.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Benchmark: auth0_list_logs — q parameter description gap
+ *
+ * Source: 661 observed 400 errors on GET /api/v2/logs (Apr 2025–Jul 2026).
+ * Root cause: q description omits valid field names. LLM sends user_email,
+ * which does not exist in Auth0 logs. Email is indexed under user_name.
+ *
+ * BEFORE tests: document the gap — bad input causes 400.
+ * AFTER tests:  correct input succeeds.
+ * SCHEMA tests: fail before the fix, pass after. These are the commit gate.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { LOG_HANDLERS, LOG_TOOLS } from '../../src/tools/logs';
+import { mockConfig } from '../mocks/config';
+import { mockLogs } from '../mocks/auth0/logs';
+import { server } from '../setup';
+
+vi.mock('../../src/utils/logger', () => ({
+  log: vi.fn(),
+  logInfo: vi.fn(),
+  logError: vi.fn(),
+}));
+
+const { domain, token } = mockConfig;
+
+// Validates the q parameter the same way the real Auth0 API does:
+// user_email is not an indexed field — requests using it return 400.
+function withStrictLogsHandler() {
+  server.use(
+    http.get('https://*/api/v2/logs', ({ request }) => {
+      const q = new URL(request.url).searchParams.get('q') ?? '';
+      if (/user_email/.test(q)) {
+        return new HttpResponse(
+          JSON.stringify({
+            statusCode: 400,
+            error: 'Bad Request',
+            message: 'The search query string has an error: unknown field "user_email".',
+          }),
+          { status: 400, headers: { 'Content-Type': 'application/json' } }
+        );
+      }
+      return HttpResponse.json({ logs: mockLogs, total: mockLogs.length });
+    })
+  );
+}
+
+afterEach(() => server.resetHandlers());
+
+describe('Benchmark: auth0_list_logs — q field description gap', () => {
+  describe('BEFORE: schema gap — LLM sends user_email, API returns 400', () => {
+    it('query with user_email returns a 400 error', async () => {
+      withStrictLogsHandler();
+
+      const response = await LOG_HANDLERS.auth0_list_logs(
+        { token, parameters: { q: 'user_email:"ct@monaco.com"' } },
+        { domain }
+      );
+
+      expect(response.isError).toBe(true);
+      expect(response.content[0].text).toMatch(/400|Bad Request|user_email/i);
+    });
+  });
+
+  describe('AFTER: patched schema — LLM sends user_name, API returns 200', () => {
+    it('query with user_name succeeds', async () => {
+      withStrictLogsHandler();
+
+      const response = await LOG_HANDLERS.auth0_list_logs(
+        { token, parameters: { q: 'user_name:"ct@monaco.com"' } },
+        { domain }
+      );
+
+      expect(response.isError).toBe(false);
+      const parsed = JSON.parse(response.content[0].text);
+      expect(Array.isArray(parsed.logs)).toBe(true);
+    });
+
+    it('type-based filter succeeds', async () => {
+      withStrictLogsHandler();
+
+      const response = await LOG_HANDLERS.auth0_list_logs(
+        { token, parameters: { q: 'type:f' } },
+        { domain }
+      );
+
+      expect(response.isError).toBe(false);
+    });
+  });
+
+  describe('SCHEMA: q description must guide the LLM — fails before fix, passes after', () => {
+    const qSchema = LOG_TOOLS.find((t) => t.name === 'auth0_list_logs')?.inputSchema
+      ?.properties?.q as Record<string, string> | undefined;
+
+    it('lists user_name as a searchable field', () => {
+      expect(qSchema?.description).toContain('user_name');
+    });
+
+    it('explicitly names user_email as invalid', () => {
+      expect(qSchema?.description).toMatch(/user_email/i);
+    });
+
+    it('includes at least one example query', () => {
+      expect(qSchema?.description).toMatch(/example|e\.g\./i);
+    });
+  });
+});


### PR DESCRIPTION
### Changes

The \`q\` parameter description in \`auth0_list_logs\` lacked valid field names, causing LLMs to construct invalid Lucene queries. The most common error was sending \`user_email\` — a field that does not exist in Auth0 logs. Email is indexed under \`user_name\`.

**Error reproduced in production:**
\`\`\`
400 Bad Request: The search query string has an error: unknown field "user_email"
\`\`\`

**Before:**
\`\`\`typescript
q: {
  type: 'string',
  description: 'Query in Lucene query string syntax. Optional, used for filtering logs.'
}
\`\`\`

**After:**
\`\`\`typescript
q: {
  type: 'string',
  description:
    'Lucene query string to filter logs. ' +
    'Valid fields: user_name (stores email for database users), user_id, type, ' +
    'client_id, client_name, ip, connection, description, date. ' +
    'Examples: user_name:"john@example.com", type:f, client_name:MyApp AND type:fp. ' +
    'Do NOT use user_email — this field does not exist in Auth0 logs.'
}
\`\`\`

Valid fields sourced from the [Auth0 log search query syntax docs](https://auth0.com/docs/logs/log-search-query-syntax#searchable-fields) and verified against the Auth0 Node SDK v4.37.1.

### References

Observed in 661 production errors on `GET /api/v2/logs` (Apr 2025–Jul 2026). E2E eval methodology and results: https://github.com/AkxenTech/auth0-mcp-benchmarks

### Testing

`test/benchmark/logs.benchmark.test.ts` (added in this PR) encodes the failure and the fix using the existing MSW mock infrastructure:

- **BEFORE tests** — confirm the mock correctly rejects `user_email` queries with 400, reproducing the production error
- **AFTER tests** — confirm corrected queries (`user_name`, `type`) return 200
- **Schema inspection tests** — assert the description contains `user_name`, explicitly warns against `user_email`, and includes examples; these fail before the fix and pass after

Run: `npm test`

Additionally, an E2E eval was run against a real Auth0 tenant across three model tiers (claude-haiku-4-5, claude-sonnet-4-6, claude-sonnet-5). `claude-haiku-4-5` — the tier that reproduces the production 400 — correctly sent `user_name` queries after the fix across all eval cases. Sonnet-tier models already inferred the correct field without the fix.

- [x] This change adds unit test coverage
- [ ] This change adds integration test coverage

### Checklist

- [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [ ] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors