### PR TITLE
fix(applications): add grant_types guidance, jwt_configuration alg enum, refresh_token sub-schema

### DIFF
--- a/src/tools/applications.ts
+++ b/src/tools/applications.ts
@@ -83,7 +83,9 @@ export const APPLICATION_TOOLS: Tool[] = [
         app_type: {
           type: 'string',
           enum: ['spa', 'native', 'non_interactive', 'regular_web'],
-          description: 'Type of client used to determine which settings are applicable.',
+          description:
+            'Application type. Use non_interactive for Machine-to-Machine (M2M) or API-to-API apps. ' +
+            'Use spa for Single Page Apps, regular_web for server-rendered apps, native for mobile/desktop.',
         },
         description: {
           type: 'string',
@@ -148,16 +150,74 @@ export const APPLICATION_TOOLS: Tool[] = [
         },
         grant_types: {
           type: 'array',
-          items: { type: 'string' },
-          description: 'List of grant types for this client',
+          items: { type: 'string', minLength: 1 },
+          description:
+            'List of grant types supported for this application. Can include ' +
+            '`authorization_code`, `implicit`, `refresh_token`, `client_credentials`, `password`, ' +
+            '`http://auth0.com/oauth/grant-type/password-realm`, ' +
+            '`http://auth0.com/oauth/grant-type/mfa-oob`, ' +
+            '`http://auth0.com/oauth/grant-type/mfa-otp`, ' +
+            '`http://auth0.com/oauth/grant-type/mfa-recovery-code`, ' +
+            '`urn:openid:params:grant-type:ciba`, ' +
+            '`urn:ietf:params:oauth:grant-type:device_code`, and ' +
+            '`urn:auth0:params:oauth:grant-type:token-exchange:federated-connection-access-token`.',
         },
         jwt_configuration: {
           type: 'object',
-          description: 'JWT configuration settings',
+          description: 'JWT configuration.',
+          properties: {
+            alg: {
+              type: 'string',
+              enum: ['HS256', 'RS256', 'RS512', 'PS256'],
+              description: 'JWT signing algorithm.',
+            },
+            lifetime_in_seconds: {
+              type: 'number',
+              description: 'Token expiry in seconds.',
+            },
+          },
         },
         refresh_token: {
-          type: 'object',
-          description: 'Refresh token configuration',
+          type: ['object', 'null'],
+          description: 'Refresh token configuration.',
+          additionalProperties: false,
+          properties: {
+            rotation_type: {
+              type: 'string',
+              enum: ['rotating', 'non-rotating'],
+              description: 'Rotation policy.',
+            },
+            expiration_type: {
+              type: 'string',
+              enum: ['expiring', 'non-expiring'],
+              description: 'Expiration policy.',
+            },
+            leeway: {
+              type: 'integer',
+              minimum: 0,
+              description: 'Grace period in seconds before breach detection triggers.',
+            },
+            token_lifetime: {
+              type: 'integer',
+              minimum: 1,
+              maximum: 157788000,
+              description: 'Refresh token lifetime in seconds.',
+            },
+            infinite_token_lifetime: {
+              type: 'boolean',
+              description: 'If true, tokens never expire (overrides token_lifetime).',
+            },
+            idle_token_lifetime: {
+              type: 'integer',
+              minimum: 1,
+              description: 'Idle lifetime in seconds.',
+            },
+            infinite_idle_token_lifetime: {
+              type: 'boolean',
+              description: 'If true, tokens do not expire from inactivity (overrides idle_token_lifetime).',
+            },
+          },
+          required: ['rotation_type', 'expiration_type'],
         },
         mobile: {
           type: 'object',
@@ -221,7 +281,9 @@ export const APPLICATION_TOOLS: Tool[] = [
         app_type: {
           type: 'string',
           enum: ['spa', 'native', 'non_interactive', 'regular_web'],
-          description: 'Type of client used to determine which settings are applicable',
+          description:
+            'Application type. Use non_interactive for Machine-to-Machine (M2M) or API-to-API apps. ' +
+            'Use spa for Single Page Apps, regular_web for server-rendered apps, native for mobile/desktop.',
         },
         description: {
           type: 'string',
@@ -250,8 +312,17 @@ export const APPLICATION_TOOLS: Tool[] = [
         },
         grant_types: {
           type: 'array',
-          items: { type: 'string' },
-          description: 'List of grant types for this client',
+          items: { type: 'string', minLength: 1 },
+          description:
+            'List of grant types supported for this application. Can include ' +
+            '`authorization_code`, `implicit`, `refresh_token`, `client_credentials`, `password`, ' +
+            '`http://auth0.com/oauth/grant-type/password-realm`, ' +
+            '`http://auth0.com/oauth/grant-type/mfa-oob`, ' +
+            '`http://auth0.com/oauth/grant-type/mfa-otp`, ' +
+            '`http://auth0.com/oauth/grant-type/mfa-recovery-code`, ' +
+            '`urn:openid:params:grant-type:ciba`, ' +
+            '`urn:ietf:params:oauth:grant-type:device_code`, and ' +
+            '`urn:auth0:params:oauth:grant-type:token-exchange:federated-connection-access-token`.',
         },
         token_endpoint_auth_method: {
           type: 'string',
@@ -290,11 +361,60 @@ export const APPLICATION_TOOLS: Tool[] = [
         },
         jwt_configuration: {
           type: 'object',
-          description: 'JWT configuration settings',
+          description: 'JWT configuration.',
+          properties: {
+            alg: {
+              type: 'string',
+              enum: ['HS256', 'RS256', 'RS512', 'PS256'],
+              description: 'JWT signing algorithm.',
+            },
+            lifetime_in_seconds: {
+              type: 'number',
+              description: 'Token expiry in seconds.',
+            },
+          },
         },
         refresh_token: {
-          type: 'object',
-          description: 'Refresh token configuration',
+          type: ['object', 'null'],
+          description: 'Refresh token configuration.',
+          additionalProperties: false,
+          properties: {
+            rotation_type: {
+              type: 'string',
+              enum: ['rotating', 'non-rotating'],
+              description: 'Rotation policy.',
+            },
+            expiration_type: {
+              type: 'string',
+              enum: ['expiring', 'non-expiring'],
+              description: 'Expiration policy.',
+            },
+            leeway: {
+              type: 'integer',
+              minimum: 0,
+              description: 'Grace period in seconds before breach detection triggers.',
+            },
+            token_lifetime: {
+              type: 'integer',
+              minimum: 1,
+              maximum: 157788000,
+              description: 'Refresh token lifetime in seconds.',
+            },
+            infinite_token_lifetime: {
+              type: 'boolean',
+              description: 'If true, tokens never expire (overrides token_lifetime).',
+            },
+            idle_token_lifetime: {
+              type: 'integer',
+              minimum: 1,
+              description: 'Idle lifetime in seconds.',
+            },
+            infinite_idle_token_lifetime: {
+              type: 'boolean',
+              description: 'If true, tokens do not expire from inactivity (overrides idle_token_lifetime).',
+            },
+          },
+          required: ['rotation_type', 'expiration_type'],
         },
         mobile: {
           type: 'object',


### PR DESCRIPTION
### Changes

Three schema gaps in `auth0_create_application` and `auth0_update_application` caused LLMs to generate invalid field values, resulting in 400 errors on `POST /api/v2/clients` and `PATCH /api/v2/clients/{id}`.

**1. `grant_types` — missing valid-value guidance**

The field was a bare string array with no guidance on accepted values. LLMs sent short-form strings (`mfa-recovery-code`, `device_code`) instead of the required full grant-type URIs.

A strict enum on `items` was considered but rejected — it caused models to over-fit and include only listed values even when standard grants like `authorization_code` were also needed. Description-based guidance was chosen instead.

**2. `jwt_configuration` — opaque object**

Expanded from `{ type: 'object', description: 'JWT configuration settings' }` to a typed sub-schema. The `alg` enum is sourced from the Auth0 Node SDK v4.37.1 `ClientCreateJwtConfigurationAlgEnum`:

```typescript
jwt_configuration: {
  type: 'object',
  properties: {
    alg: { type: 'string', enum: ['HS256', 'RS256', 'RS512', 'PS256'] },
    lifetime_in_seconds: { type: 'number', description: 'Token expiry in seconds.' },
  },
}
```

**3. `refresh_token` — opaque object causing wrong nesting**

Without a sub-schema, `claude-haiku-4-5` sent `{"rotation":{"type":"rotating"}}` — a nested shape the API rejects. The fix adds the full `ClientRefreshToken` interface as a sub-schema with `additionalProperties: false`, `required: ['rotation_type', 'expiration_type']`, and integer bounds sourced from the Auth0 Node SDK v4.37.1.

Token delta: `auth0_create_application` 80 → 1199 tokens, `auth0_update_application` 80 → 1168 tokens. Both remain within the 1,200 per-tool budget.

### References

Observed in 761 production errors on `POST /api/v2/clients` and `PATCH /api/v2/clients/{id}` (Apr 2025–Jul 2026). E2E eval methodology and results: https://github.com/AkxenTech/auth0-mcp-benchmarks

### Testing

An E2E eval was run against a real Auth0 tenant across three model tiers (claude-haiku-4-5, claude-sonnet-4-6, claude-sonnet-5) with 4 cases:

| Case | BEFORE (haiku) | AFTER (all models) | Tenant |
|------|---------------|-------------------|--------|
| grant_types: MFA recovery | `["mfa-recovery-code"]` | full URI form ✓ | 200 |
| grant_types: device code | `["device_code"]` | URN form ✓ | 200 |
| jwt_configuration: RS256 | `{"alg":"RS256"}` ✓ | `{"alg":"RS256"}` ✓ | 200 |
| refresh_token: rotating | `{"rotation":{"type":"rotating"}}` ✗ | `{"rotation_type":"rotating","expiration_type":"expiring","leeway":10}` ✓ | 200 |

12/12 AFTER assertions pass across all models.

Run the existing test suite: `npm test` — no regressions.

- [ ] This change adds unit test coverage
- [ ] This change adds integration test coverage

### Checklist

- [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [ ] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors