### PR TITLE
fix(forms): add style sub-schema with css-only constraint, add name length bounds

### DIFF
--- a/src/tools/forms.ts
+++ b/src/tools/forms.ts
@@ -60,38 +60,63 @@ export const FORM_TOOLS: Tool[] = [
       properties: {
         name: {
           type: 'string',
-          description: 'Name of the form. Required.',
+          minLength: 1,
+          maxLength: 150,
+          description: 'Form name. Required. Maximum 150 characters.',
         },
         messages: {
           type: 'object',
-          description: 'Message settings for the form',
+          description:
+            'Message settings for the form. IMPORTANT: the Auth0 Forms API enforces strict field validation ' +
+            '(additionalProperties: false). Only send fields defined in the Auth0 Forms API spec.',
         },
         languages: {
           type: 'object',
-          description: 'Language settings for the form',
+          description:
+            'Language settings for the form. IMPORTANT: strict field validation enforced — ' +
+            'only send fields defined in the Auth0 Forms API spec.',
         },
         translations: {
           type: 'object',
-          description: 'Translations for form content',
+          description:
+            'Locale translations for form content. ' +
+            'Outer keys are locale codes (e.g. "fr", "es", "pt-BR"). ' +
+            'Inner keys are translation string identifiers with their translated values.',
         },
         nodes: {
           type: 'array',
-          description: 'Nodes defining form structure and behavior',
+          description:
+            'Form nodes defining structure and routing. IMPORTANT: the Auth0 Forms API enforces strict field ' +
+            'validation (additionalProperties: false) at every level. Each node must be one of: FormFlow, ' +
+            'FormRouter, or FormStep with exact required fields. Unknown fields at any depth cause a 400 error.',
           items: {
             type: 'object',
           },
         },
         start: {
           type: 'object',
-          description: 'Settings for form start configuration',
+          description:
+            'Settings for form start configuration. IMPORTANT: strict field validation enforced — ' +
+            'only send fields defined in the Auth0 Forms API spec.',
         },
         ending: {
           type: 'object',
-          description: 'Settings for form completion',
+          description:
+            'Settings for form completion. IMPORTANT: strict field validation enforced — ' +
+            'only send fields defined in the Auth0 Forms API spec.',
         },
         style: {
           type: 'object',
-          description: 'Style settings for the form',
+          additionalProperties: false,
+          description: 'CSS styling for the form. Only the css field is accepted — do not send color, theme, font, or other properties.',
+          properties: {
+            css: {
+              type: 'string',
+              minLength: 1,
+              maxLength: 5000,
+              description: 'Raw CSS string for the form. This is the only accepted style field.',
+            },
+          },
         },
       },
       required: ['name'],
@@ -119,38 +144,60 @@ export const FORM_TOOLS: Tool[] = [
         },
         name: {
           type: 'string',
-          description: 'Name of the form',
+          minLength: 1,
+          maxLength: 150,
+          description: 'Form name. Maximum 150 characters.',
         },
         messages: {
           type: 'object',
-          description: 'Message settings for the form',
+          description:
+            'Message settings for the form. IMPORTANT: the Auth0 Forms API enforces strict field validation ' +
+            '(additionalProperties: false). Only send fields defined in the Auth0 Forms API spec.',
         },
         languages: {
           type: 'object',
-          description: 'Language settings for the form',
+          description:
+            'Language settings for the form. IMPORTANT: strict field validation enforced — ' +
+            'only send fields defined in the Auth0 Forms API spec.',
         },
         translations: {
           type: 'object',
-          description: 'Translations for form content',
+          description:
+            'Locale translations for form content. ' +
+            'Outer keys are locale codes (e.g. "fr", "es", "pt-BR"). ' +
+            'Inner keys are translation string identifiers with their translated values.',
         },
         nodes: {
           type: 'array',
-          description: 'Nodes defining form structure and behavior',
+          description:
+            'Form nodes defining structure and routing. IMPORTANT: the Auth0 Forms API enforces strict field ' +
+            'validation (additionalProperties: false) at every level. Each node must be one of: FormFlow, ' +
+            'FormRouter, or FormStep with exact required fields. Unknown fields at any depth cause a 400 error.',
           items: {
             type: 'object',
           },
         },
         start: {
           type: 'object',
-          description: 'Settings for form start configuration',
+          description:
+            'Settings for form start configuration. IMPORTANT: strict field validation enforced — ' +
+            'only send fields defined in the Auth0 Forms API spec.',
         },
         ending: {
           type: 'object',
-          description: 'Settings for form completion',
+          description:
+            'Settings for form completion. IMPORTANT: strict field validation enforced — ' +
+            'only send fields defined in the Auth0 Forms API spec.',
         },
         style: {
           type: 'object',
-          description: 'Style settings for the form',
+          description: 'CSS styling for the form. Include this field to apply custom CSS. Only the css field is accepted.',
+          properties: {
+            css: {
+              type: 'string',
+              description: 'Raw CSS string for the form.',
+            },
+          },
         },
       },
       required: ['id'],


### PR DESCRIPTION
### Changes

Two schema gaps in `auth0_create_form` and `auth0_update_form` caused LLMs to generate invalid field values, resulting in 400 errors on the forms endpoints.

**1. `style` had no sub-schema**

The field was described as an opaque `object` with no properties. LLMs invented property names (`backgroundColor`, `textColor`, `color`, `font`, `theme`, etc.) that do not exist in the Forms API. `PostFormsRequestStyle` has exactly one property: `css?: string`.

The create and update tools use intentionally different `style` schemas:

```typescript
// auth0_create_form — strict
style: {
  type: 'object',
  additionalProperties: false,
  description: 'CSS styling for the form. Only the css field is accepted — do not send color, theme, font, or other properties.',
  properties: {
    css: { type: 'string', minLength: 1, maxLength: 5000 },
  },
}

// auth0_update_form — relaxed (no additionalProperties: false)
// Strict validation on the create schema causes claude-sonnet-4-6 to conservatively
// omit optional fields on the update tool — a known cross-tool contamination effect.
style: {
  type: 'object',
  description: 'CSS styling for the form. Include this field to apply custom CSS. Only the css field is accepted.',
  properties: {
    css: { type: 'string' },
  },
}
```

**2. `name` — no length constraints**

Added `minLength: 1` and `maxLength: 150` to both tools. The Forms API enforces a 150-character limit.

Additionally improved descriptions on `messages`, `languages`, `nodes`, `start`, and `ending` to warn that the Forms API enforces strict field validation (`additionalProperties: false`) at every nesting level — unknown fields at any depth cause a 400 error.

### References

Observed in 253 production errors on forms endpoints (Apr 2025–Jul 2026). E2E eval methodology and results: https://github.com/AkxenTech/auth0-mcp-benchmarks

### Testing

An E2E eval was run against a real Auth0 tenant across three model tiers (claude-haiku-4-5, claude-sonnet-4-6, claude-sonnet-5) with 4 cases:

| Case | BEFORE | AFTER | Tenant |
|------|--------|-------|--------|
| style: css-only (create) | invented props (`color`, `background`, etc.) | `css` only ✓ | 200 |
| style.css: string value | varies | string ✓ | 200 |
| name: within maxLength | varies | ≤150 chars ✓ | 200 |
| style: css-only (update) | invented props | `css` only ✓ (haiku, sonnet-5) / absent ✗ (sonnet-4-6) | 200 / skip |

11/12 AFTER assertions pass. The one expected failure is the `style: css-only on update` case for `claude-sonnet-4-6`. This model omits the `style` field entirely on update — a known cross-tool contamination effect where `additionalProperties: false` on the create schema causes it to over-cautiously omit optional fields on the update tool. The test is left as a documented failing assertion rather than a special-cased pass.

Run the existing test suite: `npm test` — no regressions.

- [ ] This change adds unit test coverage
- [ ] This change adds integration test coverage

### Checklist

- [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [ ] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors